### PR TITLE
fix: make wait wake on any message, not just @-mentions

### DIFF
--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Wait for a new message addressed to you"
-#USAGE flag "--for <for>" help="Your agent name" required=#true
+#USAGE flag "--for <for>" help="Your agent name (if set, ignores your own messages)"
 #USAGE flag "--chat <chat>" help="Chat name (default: auto-detect from git remote)"
 #USAGE flag "--timeout <seconds>" help="Max seconds to wait (0 = forever)" default="120"
 set -eo pipefail
@@ -10,7 +10,7 @@ source "$REPO_DIR/lib/chat.sh"
 chat_resolve "${usage_chat:-}"
 chat_init
 
-agent="$usage_for"
+agent="${usage_for:-}"
 timeout="${usage_timeout:-120}"
 
 # Record where we are now
@@ -18,25 +18,49 @@ start_lines=$(chat_line_count)
 elapsed=0
 interval=3
 
-echo "Waiting for messages for @${agent} in ${CHAT_NAME}... (timeout: ${timeout}s)"
+if [ -n "$agent" ]; then
+  echo "Waiting for messages in ${CHAT_NAME} (ignoring own)... (timeout: ${timeout}s)"
+else
+  echo "Waiting for messages in ${CHAT_NAME}... (timeout: ${timeout}s)"
+fi
 
 while true; do
   current_lines=$(chat_line_count)
 
   if [ "$current_lines" -gt "$start_lines" ]; then
-    # New content — check if it mentions us
+    # New content arrived
     new_content=$(tail -n +"$((start_lines + 1))" "$CHAT_FILE")
-    if echo "$new_content" | grep -qi "@${agent}"; then
+
+    if [ -z "$agent" ]; then
+      # No --for: wake on any new message
       echo ""
       echo "New message:"
       echo "$new_content" | chat_format_messages
       exit 0
+    else
+      # --for set: wake on any message NOT from this agent
+      # Extract sender names from ### headers (format: "### name — timestamp")
+      has_other_sender=false
+      while IFS= read -r header; do
+        sender=$(echo "$header" | sed -E 's/^### (.+) — .+$/\1/')
+        if [ "$sender" != "$agent" ]; then
+          has_other_sender=true
+          break
+        fi
+      done <<< "$(echo "$new_content" | grep '^### ')"
+
+      if [ "$has_other_sender" = true ]; then
+        echo ""
+        echo "New message:"
+        echo "$new_content" | chat_format_messages
+        exit 0
+      fi
     fi
   fi
 
   if [ "$timeout" -gt 0 ] && [ "$elapsed" -ge "$timeout" ]; then
     echo ""
-    echo "Timed out after ${timeout}s — no messages for @${agent}."
+    echo "Timed out after ${timeout}s — no new messages."
     exit 1
   fi
 


### PR DESCRIPTION
## Summary
- `chat wait --for <agent>` previously required `@agent` in the message body to wake up — but nobody actually @-mentions each other, so wait always timed out
- `--for` is now optional: without it, wakes on any new message
- With `--for`, wakes on any message from a *different* sender (filters out your own messages)

## Context
Discovered while collaborating with Zeke — we kept timing out on each other because the `@mention` filter never matched. Zeke is separately fixing the cursor-based bug (wait missing messages sent before it starts) in a parallel PR.

## Test plan
- [ ] `chat wait` (no --for) wakes on any new message
- [ ] `chat wait --for baby-joel` wakes when zeke sends, ignores own messages
- [ ] `chat wait --for baby-joel --timeout 5` times out correctly when no messages arrive
- [ ] Syntax check passes (`bash -n`)