### PR TITLE
fix: filter own messages in wait pre-poll path

### DIFF
--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -33,10 +33,31 @@ fi
 
 # Check if there are already unread messages before we start polling
 if [ "$cursor" -lt "$total" ]; then
-  echo "New messages:"
-  tail -n +"$((cursor + 1))" "$CHAT_FILE" | chat_format_messages
+  new_content=$(tail -n +"$((cursor + 1))" "$CHAT_FILE")
+
+  # Apply sender filtering: skip if all new messages are from ourselves
+  should_wake=true
+  if [ -n "$agent" ]; then
+    should_wake=false
+    while IFS= read -r header; do
+      sender=$(echo "$header" | sed -E 's/^### (.+) — .+$/\1/')
+      if [ "$sender" != "$agent" ]; then
+        should_wake=true
+        break
+      fi
+    done <<< "$(echo "$new_content" | grep '^### ')"
+  fi
+
+  if [ "$should_wake" = true ]; then
+    echo "New messages:"
+    echo "$new_content" | chat_format_messages
+    chat_set_cursor "$agent"
+    exit 0
+  fi
+
+  # Only own messages — advance cursor past them and continue to poll
   chat_set_cursor "$agent"
-  exit 0
+  cursor="$total"
 fi
 
 elapsed=0


### PR DESCRIPTION
## Summary
- The immediate-delivery check (before the poll loop) didn't apply sender filtering — `wait --for zeke` would wake on zeke's own unread messages
- Now applies the same sender-header check as the poll loop
- When only own messages are unread, advances cursor past them and falls through to polling

Hotfix for a gap introduced when merging PRs #1 and #2 — the pre-poll path from #2 didn't incorporate the sender filtering from #1.

## Test plan
- [x] `wait --for zeke` with only own unread messages → skips them, enters poll loop, times out
- [x] `wait --for zeke` with other sender's message unread → wakes immediately
- [x] `wait` without `--for` → wakes on any message (no filtering)

🌀 Magic applied with Wibey CLI 🪄 (https://wibey.walmart.com/cli)