### PR TITLE
feat: add chat view for real-time chat monitoring

### DIFF
--- a/.mise/tasks/view
+++ b/.mise/tasks/view
@@ -24,8 +24,19 @@ else
 fi
 echo ""
 
-# Show recent history
-tail -n "$tail_lines" "$CHAT_FILE" | chat_format_messages
+# Show recent history — seek backward to nearest message header so we
+# don't render a partial message block missing its ### header line
+recent=$(tail -n "$tail_lines" "$CHAT_FILE")
+if [ -n "$recent" ]; then
+  # Find first ### header in the tail output; drop lines before it
+  first_header=$(echo "$recent" | grep -n '^### ' | head -1 | cut -d: -f1)
+  if [ -n "$first_header" ]; then
+    echo "$recent" | tail -n +"$first_header" | chat_format_messages
+  else
+    # No headers in window — show raw (probably just the file preamble)
+    echo "$recent"
+  fi
+fi
 
 echo ""
 if command -v gum &>/dev/null; then

--- a/.mise/tasks/view
+++ b/.mise/tasks/view
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#MISE description="Watch a chat in real-time"
+#USAGE flag "--chat <chat>" help="Chat name (default: auto-detect from git remote)"
+#USAGE flag "--tail <lines>" help="Number of recent lines to show on start" default="50"
+set -eo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$REPO_DIR/lib/chat.sh"
+chat_resolve "${usage_chat:-}"
+chat_init
+
+tail_lines="${usage_tail:-50}"
+
+if [ ! -f "$CHAT_FILE" ]; then
+  echo "No chat history for ${CHAT_NAME}."
+  exit 0
+fi
+
+# Header
+if command -v gum &>/dev/null; then
+  gum style --foreground 39 --bold "📡 Watching ${CHAT_NAME} (Ctrl+C to exit)"
+else
+  echo "📡 Watching ${CHAT_NAME} (Ctrl+C to exit)"
+fi
+echo ""
+
+# Show recent history
+tail -n "$tail_lines" "$CHAT_FILE" | chat_format_messages
+
+echo ""
+if command -v gum &>/dev/null; then
+  echo "--- live tail ---" | gum style --foreground 240
+else
+  echo "--- live tail ---"
+fi
+
+# Track where we are so we only format new complete messages
+last_line=$(wc -l < "$CHAT_FILE" | tr -d ' ')
+
+# Tail for new content, processing complete message blocks
+while true; do
+  current_line=$(wc -l < "$CHAT_FILE" | tr -d ' ')
+
+  if [ "$current_line" -gt "$last_line" ]; then
+    # New content — extract and format it
+    tail -n +"$((last_line + 1))" "$CHAT_FILE" | chat_format_messages
+    last_line="$current_line"
+  fi
+
+  sleep 1
+done

--- a/lib/chat.sh
+++ b/lib/chat.sh
@@ -134,6 +134,14 @@ chat_list() {
   printf '%s\n' "${chats[@]}"
 }
 
+# Trim trailing blank lines from a string
+# Usage: result=$(_chat_trim_trailing_newlines "$text")
+_chat_trim_trailing_newlines() {
+  local text="$1"
+  while [[ "$text" =~ $'\n'$ ]]; do text="${text%$'\n'}"; done
+  printf '%s' "$text"
+}
+
 # Format a message block for display using gum
 # Usage: chat_format_message "header_line" "body_text"
 chat_format_messages() {
@@ -155,8 +163,7 @@ chat_format_messages() {
       local match_time="${BASH_REMATCH[2]}"
       # Print previous message if any
       if [ -n "$header" ]; then
-        # Trim trailing blank lines from body
-        while [[ "$body" =~ $'\n'$ ]]; do body="${body%$'\n'}"; done
+        body=$(_chat_trim_trailing_newlines "$body")
         _chat_render_block "$header" "$body" "$first"
         first=false
       fi
@@ -173,7 +180,7 @@ chat_format_messages() {
 
   # Render last message
   if [ -n "$header" ]; then
-    while [[ "$body" =~ $'\n'$ ]]; do body="${body%$'\n'}"; done
+    body=$(_chat_trim_trailing_newlines "$body")
     _chat_render_block "$header" "$body" "$first"
   fi
 }

--- a/lib/chat.sh
+++ b/lib/chat.sh
@@ -150,12 +150,17 @@ chat_format_messages() {
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ "$line" =~ ^###\ (.+)\ —\ (.+)$ ]]; then
+      # Save matches before any regex that could clobber BASH_REMATCH
+      local match_name="${BASH_REMATCH[1]}"
+      local match_time="${BASH_REMATCH[2]}"
       # Print previous message if any
       if [ -n "$header" ]; then
+        # Trim trailing blank lines from body
+        while [[ "$body" =~ $'\n'$ ]]; do body="${body%$'\n'}"; done
         _chat_render_block "$header" "$body" "$first"
         first=false
       fi
-      header="${BASH_REMATCH[1]}  ${BASH_REMATCH[2]}"
+      header="${match_name}  ${match_time}"
       body=""
       in_header=true
     elif [ "$in_header" = true ]; then
@@ -168,6 +173,7 @@ chat_format_messages() {
 
   # Render last message
   if [ -n "$header" ]; then
+    while [[ "$body" =~ $'\n'$ ]]; do body="${body%$'\n'}"; done
     _chat_render_block "$header" "$body" "$first"
   fi
 }


### PR DESCRIPTION
## Summary
- New `chat view` task for live-tailing a chat room
- Shows recent history on start (`--tail N`, default 50 lines), then polls for new messages every second
- Renders through `chat_format_messages` for consistent styling with gum
- Supports `--chat` flag for room selection (default: auto-detect from git remote)
- Ctrl+C to exit

## Context
Or wants real-time visibility into agent-to-agent chats. This is v1 — read-only viewer. Interactive input (v2) will come later, potentially using zellij.

## Test plan
- [x] `chat view --chat test-room` shows history and live-tails new messages
- [x] `gum style` formatting works (fixed leading-dash arg parsing issue)
- [x] Graceful fallback when gum is not installed
- [ ] Zeke review