### PR TITLE
feat: add send-before-read guard

### DIFF
--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -2,6 +2,7 @@
 #MISE description="Send a message to a chat"
 #USAGE flag "--from <from>" help="Your agent name" required=#true
 #USAGE flag "--chat <chat>" help="Chat name (default: auto-detect from git remote)"
+#USAGE flag "-f --force" help="Send even if there are unread messages"
 #USAGE arg "<message>" help="The message to send (or - for stdin)"
 set -eo pipefail
 
@@ -30,6 +31,19 @@ if [ "$line_count" -gt "$MAX_LINES" ]; then
   echo "Error: message too long (${line_count} lines, max ${MAX_LINES})" >&2
   echo "Tip: write to /tmp/chat-attachment-\$(date +%Y%m%d-%H%M)-<topic>.md and reference it" >&2
   exit 1
+fi
+
+# Guard: warn if sender has unread messages (skip for first-time senders)
+if [ "${usage_force:-false}" != "true" ]; then
+  cursor=$(chat_get_cursor "$from")
+  if [ "$cursor" -gt 0 ]; then
+    unread=$(chat_count_new "$from")
+    if [ "$unread" -gt 0 ]; then
+      echo "Error: you have ${unread} unread message(s) in ${CHAT_NAME}." >&2
+      echo "Run 'chat read' first, or use --force to send anyway." >&2
+      exit 1
+    fi
+  fi
 fi
 
 chat_append "$from" "$message"


### PR DESCRIPTION
## Summary

- Adds a guard to `send` that checks for unread messages before allowing the sender to post
- If the sender has unread messages, `send` aborts with a helpful error pointing to `chat read`
- First-time senders (cursor=0) are exempt to avoid false positives on initial join
- `--force` / `-f` flag bypasses the check for intentional overrides

## Motivation

Prevents the common divergence pattern: Agent A sends a message, Agent B replies without reading A's first, and the conversation forks. The guard makes this a visible error rather than a silent problem.

## Test plan

- [x] First-time sender (cursor=0) — sends successfully, no guard triggered
- [x] Sender with unread messages — blocked with clear error message
- [x] `--force` flag — bypasses the guard, sends successfully
- [x] `mise run send --help` shows the new `-f --force` flag