### PR TITLE
fix: drop org prefix from auto-detected channel names

### DIFF
--- a/lib/chat.sh
+++ b/lib/chat.sh
@@ -4,15 +4,15 @@
 CHAT_DATA_DIR="${CHAT_DATA_DIR:-$HOME/.local/share/chat}"
 
 # Detect chat name from git remote origin of the caller's directory
-# Returns org-repo (slashes replaced with -) or empty string
+# Returns the repo name (last path component, no org prefix) or empty string
 _chat_detect_repo() {
   local dir="${CALLER_PWD:-$PWD}"
   local url
   url=$(git -C "$dir" remote get-url origin 2>/dev/null) || return 1
-  # Strip protocol, host, .git suffix → org/repo
+  # Strip protocol, host, .git suffix → org/repo, then take last component
   local path
   path=$(echo "$url" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##; s/\.git$//')
-  [ -n "$path" ] && echo "$path" | tr '/' '-'
+  [ -n "$path" ] && basename "$path"
 }
 
 # Resolve which chat we're targeting

--- a/test/chat_lib.bats
+++ b/test/chat_lib.bats
@@ -29,6 +29,66 @@ load test_helper
 }
 
 # ============================================================================
+# _chat_detect_repo — git remote auto-detection
+# ============================================================================
+
+@test "detect_repo: extracts repo name from HTTPS remote" {
+  _setup_git_remote "https://github.com/ricon-family/den.git"
+  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+  [ "$CHAT_NAME" = "den" ]
+}
+
+@test "detect_repo: extracts repo name from SSH remote" {
+  _setup_git_remote "git@github.com:KnickKnackLabs/chat.git"
+  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+  [ "$CHAT_NAME" = "chat" ]
+}
+
+@test "detect_repo: extracts repo name from GHE HTTPS remote" {
+  _setup_git_remote "https://gecgithub01.walmart.com/Torbit/okwai.git"
+  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+  [ "$CHAT_NAME" = "okwai" ]
+}
+
+@test "detect_repo: strips .git suffix" {
+  _setup_git_remote "https://github.com/org/myrepo.git"
+  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+  [ "$CHAT_NAME" = "myrepo" ]
+}
+
+@test "detect_repo: works without .git suffix" {
+  _setup_git_remote "https://github.com/org/myrepo"
+  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+  [ "$CHAT_NAME" = "myrepo" ]
+}
+
+@test "detect_repo: no-org remote still works" {
+  _setup_git_remote "https://github.com/solo-repo.git"
+  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+  [ "$CHAT_NAME" = "solo-repo" ]
+}
+
+@test "detect_repo: falls back to global when no git repo" {
+  CALLER_PWD="$BATS_TEST_TMPDIR" chat_resolve ""
+  [ "$CHAT_NAME" = "global" ]
+}
+
+@test "detect_repo: different orgs same repo name resolve to same channel" {
+  # This is intentional — shared name = shared channel
+  _setup_git_remote "https://github.com/org-a/shared.git"
+  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+  local name_a="$CHAT_NAME"
+
+  # Reset and set up a different org
+  _setup_git_remote "https://github.com/org-b/shared.git"
+  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+  local name_b="$CHAT_NAME"
+
+  [ "$name_a" = "$name_b" ]
+  [ "$name_a" = "shared" ]
+}
+
+# ============================================================================
 # chat_init
 # ============================================================================
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -16,6 +16,18 @@ teardown() {
   rm -rf "$CHAT_DATA_DIR"
 }
 
+# Helper: create a fake git repo with a specific remote URL
+# Usage: _setup_git_remote "https://github.com/org/repo.git"
+# Creates $BATS_TEST_TMPDIR/fakerepo with the given origin remote
+_setup_git_remote() {
+  local url="$1"
+  local repo_dir="$BATS_TEST_TMPDIR/fakerepo"
+  rm -rf "$repo_dir"
+  mkdir -p "$repo_dir"
+  git -C "$repo_dir" init -q
+  git -C "$repo_dir" remote add origin "$url"
+}
+
 # Helper: send a message directly via lib (bypasses mise task overhead)
 send_message() {
   local from="$1"


### PR DESCRIPTION
## Summary

- `_chat_detect_repo()` was converting `org/repo` → `org-repo` via `tr '/' '-'`, creating surprising channel names like `ricon-family-den` instead of `den`
- This caused a split-brain when Baby Joel manually typed `--chat den` while auto-detect resolved to `ricon-family-den` — 226 messages in one file, 3 in the other
- Fix: `basename "$path"` extracts just the repo name. Name collisions across orgs are intentional (same repo name = shared channel)

## Changes

- `lib/chat.sh`: one-line fix in `_chat_detect_repo()` — `basename` instead of `tr`
- `test/chat_lib.bats`: 8 new tests (HTTPS, SSH, GHE, no-org, global fallback, collision)
- `test/test_helper.bash`: `_setup_git_remote()` helper for creating fake repos

## Test plan

- [x] All 65 tests passing (`mise run test`)
- [ ] Verify auto-detect in a real Wibey session (both `chat read` and `chat send` resolve to short name)
- [ ] After merge: migrate `ricon-family-den.md` → `den.md` data (separate task, see #9)