### PR TITLE
feat: message-level API with Python+uv mise tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 data/
+__pycache__/

--- a/.mise/tasks/merge
+++ b/.mise/tasks/merge
@@ -1,0 +1,117 @@
+#!/usr/bin/env -S uv run --script
+#MISE description="Merge two chat channels by interleaving messages by timestamp"
+#USAGE arg "<source>" help="Source channel to merge FROM (will be consumed)"
+#USAGE arg "<target>" help="Target channel to merge INTO"
+#USAGE flag "--dry-run" help="Show what would happen without writing"
+#USAGE flag "--no-tag" help="Don't annotate messages with source channel"
+# /// script
+# requires-python = ">=3.10"
+# ///
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# Add lib/ to path for shared parser
+lib_dir = Path(os.environ.get("MISE_CONFIG_ROOT", Path(__file__).resolve().parent.parent.parent)) / "lib"
+sys.path.insert(0, str(lib_dir))
+
+from parse import parse_messages, parse_header, format_message, write_chat, merge_messages
+
+CHAT_DATA_DIR = Path(os.environ.get("CHAT_DATA_DIR", Path.home() / ".local/share/chat"))
+
+def main():
+    source_name = os.environ.get("usage_source", "")
+    target_name = os.environ.get("usage_target", "")
+    dry_run = os.environ.get("usage_dry_run", "") == "true"
+    no_tag = os.environ.get("usage_no_tag", "") == "true"
+
+    if not source_name or not target_name:
+        print("Error: both <source> and <target> channel names are required", file=sys.stderr)
+        sys.exit(1)
+
+    if source_name == target_name:
+        print(f"Error: source and target are the same channel: {source_name}", file=sys.stderr)
+        sys.exit(1)
+
+    source_file = CHAT_DATA_DIR / f"{source_name}.md"
+    target_file = CHAT_DATA_DIR / f"{target_name}.md"
+
+    if not source_file.exists():
+        print(f"Error: source channel not found: {source_file}", file=sys.stderr)
+        sys.exit(1)
+
+    if not target_file.exists():
+        print(f"Error: target channel not found: {target_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse both channels
+    source_msgs = parse_messages(source_file, source=source_name)
+    target_msgs = parse_messages(target_file, source=target_name)
+
+    print(f"Source: {source_name} ({len(source_msgs)} messages)")
+    print(f"Target: {target_name} ({len(target_msgs)} messages)")
+    print(f"Total:  {len(source_msgs) + len(target_msgs)} messages")
+    print()
+
+    # Merge by timestamp
+    channels = {source_name: source_file, target_name: target_file}
+    # Use target's header (it's the surviving channel)
+    header = parse_header(target_file)
+    all_msgs = sorted(source_msgs + target_msgs, key=lambda m: m.timestamp)
+
+    tag_sources = not no_tag
+
+    if dry_run:
+        print("--- DRY RUN (no files modified) ---")
+        print()
+        for msg in all_msgs:
+            tag = f" [{msg.source}]" if tag_sources and msg.source else ""
+            print(f"  {msg.timestamp_str}  {msg.sender}{tag}  {msg.preview[:60]}")
+        print()
+        print(f"Would write {len(all_msgs)} messages to {target_file}")
+        print(f"Would remove {source_file}")
+        print(f"Would migrate cursors from .cursors/{source_name}/ to .cursors/{target_name}/")
+        return
+
+    # Write merged file
+    write_chat(target_file, header, all_msgs, tag_sources=tag_sources)
+    print(f"Wrote {len(all_msgs)} messages to {target_file}")
+
+    # Migrate cursors: for each agent, take the max of both cursors
+    source_cursor_dir = CHAT_DATA_DIR / ".cursors" / source_name
+    target_cursor_dir = CHAT_DATA_DIR / ".cursors" / target_name
+    target_cursor_dir.mkdir(parents=True, exist_ok=True)
+
+    if source_cursor_dir.exists():
+        for cursor_file in source_cursor_dir.iterdir():
+            if not cursor_file.is_file():
+                continue
+            agent = cursor_file.name
+            source_cursor = int(cursor_file.read_text().strip() or "0")
+            target_cursor_file = target_cursor_dir / agent
+            target_cursor = 0
+            if target_cursor_file.exists():
+                target_cursor = int(target_cursor_file.read_text().strip() or "0")
+
+            # After merge, set cursor to end of file (agent should re-read)
+            # This is the safest option — avoids missing messages
+            # We reset to 0 so agents see the full merged history
+            # (they can --mark-read to skip if they want)
+            target_cursor_file.write_text("0")
+            print(f"  Cursor {agent}: reset to 0 (was {source_cursor} in {source_name}, {target_cursor} in {target_name})")
+
+        shutil.rmtree(source_cursor_dir)
+        print(f"Removed {source_cursor_dir}")
+
+    # Remove source file
+    source_file.unlink()
+    print(f"Removed {source_file}")
+
+    print()
+    print(f"Merge complete. {source_name} -> {target_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.mise/tasks/merge
+++ b/.mise/tasks/merge
@@ -17,7 +17,7 @@ from pathlib import Path
 lib_dir = Path(os.environ.get("MISE_CONFIG_ROOT", Path(__file__).resolve().parent.parent.parent)) / "lib"
 sys.path.insert(0, str(lib_dir))
 
-from parse import parse_messages, parse_header, format_message, write_chat, merge_messages
+from parse import parse_messages, parse_header, write_chat
 
 CHAT_DATA_DIR = Path(os.environ.get("CHAT_DATA_DIR", Path.home() / ".local/share/chat"))
 

--- a/.mise/tasks/messages
+++ b/.mise/tasks/messages
@@ -1,0 +1,118 @@
+#!/usr/bin/env -S uv run --script
+#MISE description="List messages with structured output (filter by sender, time, format as JSON)"
+#USAGE arg "[chat]" help="Channel name (auto-detected from git remote if omitted)"
+#USAGE flag "--from <sender>" help="Filter messages by sender name"
+#USAGE flag "--after <date>" help="Show messages after this date (YYYY-MM-DD or YYYY-MM-DD HH:MM)"
+#USAGE flag "--before <date>" help="Show messages before this date (YYYY-MM-DD or YYYY-MM-DD HH:MM)"
+#USAGE flag "--last <n>" help="Show only the last N messages"
+#USAGE flag "--json" help="Output as JSON array"
+#USAGE flag "--id" help="Include message IDs in output"
+# /// script
+# requires-python = ">=3.10"
+# ///
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+lib_dir = Path(os.environ.get("MISE_CONFIG_ROOT", Path(__file__).resolve().parent.parent.parent)) / "lib"
+sys.path.insert(0, str(lib_dir))
+
+from parse import parse_messages, TIMESTAMP_FMT
+
+CHAT_DATA_DIR = Path(os.environ.get("CHAT_DATA_DIR", Path.home() / ".local/share/chat"))
+
+
+def detect_channel() -> str:
+    """Auto-detect channel from git remote (mirrors _chat_detect_repo in chat.sh)."""
+    caller_pwd = os.environ.get("CALLER_PWD", os.getcwd())
+    try:
+        url = subprocess.check_output(
+            ["git", "-C", caller_pwd, "remote", "get-url", "origin"],
+            stderr=subprocess.DEVNULL, text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "global"
+
+    # Strip protocol/host and .git suffix
+    import re
+    path = re.sub(r"^(https?://[^/]+/|git@[^:]+:)", "", url)
+    path = re.sub(r"\.git$", "", path)
+    return os.path.basename(path) if path else "global"
+
+
+def parse_date(s: str) -> datetime:
+    """Parse a date string — supports YYYY-MM-DD and YYYY-MM-DD HH:MM."""
+    for fmt in (TIMESTAMP_FMT, "%Y-%m-%d"):
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    print(f"Error: could not parse date: {s!r} (expected YYYY-MM-DD or YYYY-MM-DD HH:MM)", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    chat_name = os.environ.get("usage_chat", "") or detect_channel()
+    sender_filter = os.environ.get("usage_from", "")
+    after_str = os.environ.get("usage_after", "")
+    before_str = os.environ.get("usage_before", "")
+    last_n = os.environ.get("usage_last", "")
+    as_json = os.environ.get("usage_json", "") == "true"
+    show_ids = os.environ.get("usage_id", "") == "true"
+
+    chat_file = CHAT_DATA_DIR / f"{chat_name}.md"
+    if not chat_file.exists():
+        print(f"Error: channel not found: {chat_name}", file=sys.stderr)
+        sys.exit(1)
+
+    messages = parse_messages(chat_file)
+
+    # Apply filters
+    if sender_filter:
+        messages = [m for m in messages if m.sender.lower() == sender_filter.lower()]
+    if after_str:
+        after = parse_date(after_str)
+        messages = [m for m in messages if m.timestamp >= after]
+    if before_str:
+        before = parse_date(before_str)
+        messages = [m for m in messages if m.timestamp <= before]
+    if last_n:
+        try:
+            n = int(last_n)
+            messages = messages[-n:]
+        except ValueError:
+            print(f"Error: --last must be a number, got: {last_n!r}", file=sys.stderr)
+            sys.exit(1)
+
+    if as_json:
+        output = []
+        for msg in messages:
+            entry = {
+                "sender": msg.sender,
+                "timestamp": msg.timestamp_str,
+                "body": msg.body,
+                "preview": msg.preview,
+                "line": msg.line_number,
+            }
+            if show_ids:
+                entry["id"] = msg.id
+            output.append(entry)
+        print(json.dumps(output, indent=2))
+    else:
+        if not messages:
+            print(f"No messages in {chat_name}" + (f" matching filters" if any([sender_filter, after_str, before_str]) else ""))
+            return
+
+        print(f"{chat_name}: {len(messages)} message(s)")
+        print()
+        for msg in messages:
+            id_str = f"  {msg.id}" if show_ids else ""
+            print(f"  {msg.timestamp_str}  {msg.sender:15s}  {msg.preview[:60]}{id_str}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/parse.py
+++ b/lib/parse.py
@@ -1,0 +1,165 @@
+"""
+Chat message parser — structured access to chat markdown files.
+
+Parses the ### sender — YYYY-MM-DD HH:MM message format into
+Message objects with sender, timestamp, body, and metadata.
+"""
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+MESSAGE_HEADER_RE = re.compile(
+    r"^### (.+?) — (\d{4}-\d{2}-\d{2} \d{2}:\d{2})(.*)$"
+)
+TIMESTAMP_FMT = "%Y-%m-%d %H:%M"
+
+
+@dataclass
+class Message:
+    sender: str
+    timestamp: datetime
+    body: str
+    line_number: int
+    source: Optional[str] = None  # origin channel (for merges)
+
+    @property
+    def id(self) -> str:
+        """Stable message ID — hash of sender + timestamp + first body line."""
+        first_line = self.body.strip().split("\n")[0] if self.body.strip() else ""
+        key = f"{self.sender}|{self.timestamp.isoformat()}|{first_line}"
+        return hashlib.sha256(key.encode()).hexdigest()[:12]
+
+    @property
+    def preview(self) -> str:
+        """First non-empty line of body, truncated to 80 chars."""
+        for line in self.body.strip().split("\n"):
+            if line.strip():
+                return line.strip()[:80]
+        return ""
+
+    @property
+    def timestamp_str(self) -> str:
+        return self.timestamp.strftime(TIMESTAMP_FMT)
+
+
+def parse_header(filepath: Path) -> Optional[str]:
+    """Extract the chat file header (everything before the first message)."""
+    text = filepath.read_text()
+    # Find first message header
+    for i, line in enumerate(text.split("\n")):
+        if MESSAGE_HEADER_RE.match(line):
+            return "\n".join(text.split("\n")[:i])
+    return text  # no messages — entire file is header
+
+
+def parse_messages(filepath: Path, source: Optional[str] = None) -> list[Message]:
+    """Parse a chat markdown file into a list of Message objects."""
+    messages = []
+    lines = filepath.read_text().split("\n")
+
+    current_sender = None
+    current_timestamp = None
+    current_body_lines: list[str] = []
+    current_line_number = 0
+    header_suffix = ""
+
+    for i, line in enumerate(lines, start=1):
+        match = MESSAGE_HEADER_RE.match(line)
+        if match:
+            # Save previous message
+            if current_sender is not None:
+                body = _clean_body(current_body_lines)
+                messages.append(Message(
+                    sender=current_sender,
+                    timestamp=current_timestamp,
+                    body=body,
+                    line_number=current_line_number,
+                    source=source,
+                ))
+            # Start new message
+            current_sender = match.group(1)
+            current_timestamp = datetime.strptime(match.group(2), TIMESTAMP_FMT)
+            header_suffix = match.group(3).strip()
+            current_body_lines = []
+            current_line_number = i
+        elif current_sender is not None:
+            current_body_lines.append(line)
+
+    # Don't forget the last message
+    if current_sender is not None:
+        body = _clean_body(current_body_lines)
+        messages.append(Message(
+            sender=current_sender,
+            timestamp=current_timestamp,
+            body=body,
+            line_number=current_line_number,
+            source=source,
+        ))
+
+    return messages
+
+
+def format_message(msg: Message, tag_source: bool = False) -> str:
+    """Format a Message back into chat markdown."""
+    header = f"### {msg.sender} — {msg.timestamp_str}"
+    if tag_source and msg.source:
+        header += f" \u27f5 {msg.source}"
+    return f"\n{header}\n\n{msg.body}"
+
+
+def merge_messages(
+    channels: dict[str, Path],
+    tag_sources: bool = True,
+) -> tuple[str, list[Message]]:
+    """
+    Merge multiple channels into a single sorted message list.
+
+    Args:
+        channels: mapping of channel_name -> filepath
+        tag_sources: if True, annotate messages with origin channel
+
+    Returns:
+        (header, sorted_messages) — header from the first channel
+    """
+    all_messages: list[Message] = []
+    header = None
+
+    for name, path in channels.items():
+        if header is None:
+            header = parse_header(path)
+        msgs = parse_messages(path, source=name)
+        all_messages.extend(msgs)
+
+    # Stable sort by timestamp (preserves order within same timestamp)
+    all_messages.sort(key=lambda m: m.timestamp)
+
+    return header or "", all_messages
+
+
+def write_chat(
+    filepath: Path,
+    header: str,
+    messages: list[Message],
+    tag_sources: bool = True,
+) -> None:
+    """Write a complete chat file from header + messages."""
+    parts = [header.rstrip()]
+    for msg in messages:
+        parts.append(format_message(msg, tag_source=tag_sources))
+    filepath.write_text("\n".join(parts) + "\n")
+
+
+def _clean_body(lines: list[str]) -> str:
+    """Strip leading/trailing blank lines from message body."""
+    # Strip leading blank lines
+    while lines and not lines[0].strip():
+        lines = lines[1:]
+    # Strip trailing blank lines
+    while lines and not lines[-1].strip():
+        lines = lines[:-1]
+    return "\n".join(lines)

--- a/lib/parse.py
+++ b/lib/parse.py
@@ -66,7 +66,7 @@ def parse_messages(filepath: Path, source: Optional[str] = None) -> list[Message
     current_timestamp = None
     current_body_lines: list[str] = []
     current_line_number = 0
-    header_suffix = ""
+    current_source = source
 
     for i, line in enumerate(lines, start=1):
         match = MESSAGE_HEADER_RE.match(line)
@@ -79,12 +79,17 @@ def parse_messages(filepath: Path, source: Optional[str] = None) -> list[Message
                     timestamp=current_timestamp,
                     body=body,
                     line_number=current_line_number,
-                    source=source,
+                    source=current_source,
                 ))
             # Start new message
             current_sender = match.group(1)
             current_timestamp = datetime.strptime(match.group(2), TIMESTAMP_FMT)
-            header_suffix = match.group(3).strip()
+            # Preserve source tag from header suffix (e.g., "⟵ old-channel")
+            suffix = match.group(3).strip()
+            if suffix.startswith("\u27f5"):
+                current_source = suffix[1:].strip()
+            else:
+                current_source = source
             current_body_lines = []
             current_line_number = i
         elif current_sender is not None:
@@ -98,7 +103,7 @@ def parse_messages(filepath: Path, source: Optional[str] = None) -> list[Message
             timestamp=current_timestamp,
             body=body,
             line_number=current_line_number,
-            source=source,
+            source=current_source,
         ))
 
     return messages

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
 jq = "latest"
 gum = "latest"
+uv = "latest"
 bats = "1.13.0"

--- a/test/messages.bats
+++ b/test/messages.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+# Tests for messages and merge tasks (Python+uv)
+
+load test_helper
+
+# ============================================================================
+# Helper: create a second chat channel with messages
+# ============================================================================
+
+_setup_second_chat() {
+  local name="$1"
+  chat_resolve "$name"
+  chat_init
+  # Restore test-chat as default
+  chat_resolve "test-chat"
+  chat_init
+}
+
+_send_to() {
+  local chat="$1" from="$2" msg="$3"
+  local old_file="$CHAT_FILE"
+  local old_name="$CHAT_NAME"
+  chat_resolve "$chat"
+  chat_init
+  chat_append "$from" "$msg"
+  CHAT_FILE="$old_file"
+  CHAT_NAME="$old_name"
+}
+
+# ============================================================================
+# messages task
+# ============================================================================
+
+@test "task messages: lists messages in channel" {
+  send_message "alice" "hello from alice"
+  send_message "bob" "reply from bob"
+  run_task messages test-chat
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alice"* ]]
+  [[ "$output" == *"bob"* ]]
+  [[ "$output" == *"2 message(s)"* ]]
+}
+
+@test "task messages: --from filters by sender" {
+  send_message "alice" "msg from alice"
+  send_message "bob" "msg from bob"
+  send_message "alice" "another from alice"
+  run_task messages test-chat --from alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2 message(s)"* ]]
+  [[ "$output" == *"alice"* ]]
+}
+
+@test "task messages: --last limits count" {
+  send_message "alice" "first"
+  send_message "bob" "second"
+  send_message "carol" "third"
+  run_task messages test-chat --last 2
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2 message(s)"* ]]
+  [[ "$output" == *"bob"* ]]
+  [[ "$output" == *"carol"* ]]
+}
+
+@test "task messages: --json outputs valid JSON" {
+  send_message "alice" "json test"
+  run_task messages test-chat --json
+  [ "$status" -eq 0 ]
+  # Extract JSON (skip mise's [task] prefix lines on stderr mixed into output)
+  local json
+  json=$(echo "$output" | sed -n '/^\[$/,$ p')
+  echo "$json" | jq '.[0].sender' | grep -q "alice"
+  echo "$json" | jq '.[0].timestamp' | grep -q "2026"
+  echo "$json" | jq '.[0].body' | grep -q "json test"
+}
+
+@test "task messages: --json --id includes message IDs" {
+  send_message "alice" "id test"
+  run_task messages test-chat --json --id
+  [ "$status" -eq 0 ]
+  # Extract JSON, then check ID is a 12-char hex string
+  local json id
+  json=$(echo "$output" | sed -n '/^\[$/,$ p')
+  id=$(echo "$json" | jq -r '.[0].id')
+  [ ${#id} -eq 12 ]
+}
+
+@test "task messages: empty channel shows no messages" {
+  run_task messages test-chat
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No messages"* ]]
+}
+
+@test "task messages: nonexistent channel fails" {
+  run_task messages nonexistent
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+# ============================================================================
+# merge task
+# ============================================================================
+
+@test "task merge: dry-run shows plan without modifying files" {
+  send_message "alice" "in test-chat"
+  _send_to "other-chat" "bob" "in other-chat"
+  run_task merge other-chat test-chat --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"2 messages"* ]]
+  # Files should still exist unchanged
+  [ -f "$CHAT_DATA_DIR/other-chat.md" ]
+  [ -f "$CHAT_DATA_DIR/test-chat.md" ]
+}
+
+@test "task merge: merges source into target" {
+  send_message "alice" "target msg"
+  _send_to "source-chat" "bob" "source msg"
+  run_task merge source-chat test-chat
+  [ "$status" -eq 0 ]
+  # Source file should be removed
+  [ ! -f "$CHAT_DATA_DIR/source-chat.md" ]
+  # Target should contain both messages
+  grep -q "alice" "$CHAT_FILE"
+  grep -q "bob" "$CHAT_FILE"
+}
+
+@test "task merge: messages are tagged with source channel" {
+  send_message "alice" "target msg"
+  _send_to "old-chat" "bob" "old msg"
+  run_task merge old-chat test-chat
+  [ "$status" -eq 0 ]
+  # Source tags should appear in merged file
+  grep -q "old-chat" "$CHAT_FILE"
+}
+
+@test "task merge: --no-tag omits source annotations" {
+  send_message "alice" "target msg"
+  _send_to "old-chat" "bob" "old msg"
+  run_task merge old-chat test-chat --no-tag
+  [ "$status" -eq 0 ]
+  # The Unicode arrow tag should not appear
+  ! grep -q "⟵" "$CHAT_FILE"
+}
+
+@test "task merge: fails if source doesn't exist" {
+  run_task merge nonexistent test-chat
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "task merge: fails if source equals target" {
+  run_task merge test-chat test-chat
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"same channel"* ]]
+}
+
+@test "task merge: cursors are reset after merge" {
+  send_message "alice" "msg"
+  mark_read "alice"
+  _send_to "other-chat" "bob" "other msg"
+  # Set cursor on other-chat too
+  chat_resolve "other-chat"
+  chat_set_cursor "alice"
+  chat_resolve "test-chat"
+
+  run_task merge other-chat test-chat
+  [ "$status" -eq 0 ]
+  # Cursor should be reset to 0
+  local cursor
+  cursor=$(cat "$CHAT_DATA_DIR/.cursors/test-chat/alice")
+  [ "$cursor" = "0" ]
+}
+
+@test "task merge: source cursor dir is cleaned up" {
+  _send_to "other-chat" "bob" "msg"
+  chat_resolve "other-chat"
+  chat_set_cursor "bob"
+  chat_resolve "test-chat"
+  send_message "alice" "target"
+
+  run_task merge other-chat test-chat
+  [ "$status" -eq 0 ]
+  [ ! -d "$CHAT_DATA_DIR/.cursors/other-chat" ]
+}

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -119,25 +119,25 @@ load test_helper
 # ============================================================================
 
 @test "task send: appends message" {
-  run_task send --from alice --chat test-chat --message "hello world"
+  run_task send --from alice --chat test-chat "hello world"
   [ "$status" -eq 0 ]
   grep -q "hello world" "$CHAT_FILE"
 }
 
 @test "task send: message has sender header" {
-  run_task send --from alice --chat test-chat --message "test"
+  run_task send --from alice --chat test-chat "test"
   [ "$status" -eq 0 ]
   grep -q "^### alice" "$CHAT_FILE"
 }
 
 @test "task send: confirms with output" {
-  run_task send --from alice --chat test-chat --message "hi"
+  run_task send --from alice --chat test-chat "hi"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sent to test-chat"* ]]
 }
 
 @test "task send: rejects empty message" {
-  run_task send --from alice --chat test-chat --message ""
+  run_task send --from alice --chat test-chat ""
   [ "$status" -ne 0 ]
   [[ "$output" == *"empty"* ]]
 }
@@ -145,7 +145,7 @@ load test_helper
 @test "task send: rejects message over 10 lines" {
   local long_msg
   long_msg=$(printf 'line %s\n' $(seq 1 11))
-  run_task send --from alice --chat test-chat --message "$long_msg"
+  run_task send --from alice --chat test-chat "$long_msg"
   [ "$status" -ne 0 ]
   [[ "$output" == *"too long"* ]]
 }
@@ -153,13 +153,13 @@ load test_helper
 @test "task send: allows message at exactly 10 lines" {
   local msg
   msg=$(printf 'line %s\n' $(seq 1 10))
-  run_task send --from alice --chat test-chat --message "$msg"
+  run_task send --from alice --chat test-chat "$msg"
   [ "$status" -eq 0 ]
 }
 
 @test "task send: guard blocks send when unread messages exist" {
   # alice sends first message (cursor stays 0 — new agent, guard skips)
-  run_task send --from alice --chat test-chat --message "first"
+  run_task send --from alice --chat test-chat "first"
   [ "$status" -eq 0 ]
 
   # alice reads to set cursor > 0
@@ -169,18 +169,18 @@ load test_helper
   send_message "bob" "unread msg"
 
   # alice tries to send — guard should block
-  run_task send --from alice --chat test-chat --message "blocked"
+  run_task send --from alice --chat test-chat "blocked"
   [ "$status" -ne 0 ]
   [[ "$output" == *"unread"* ]]
 }
 
 @test "task send: --force bypasses unread guard" {
-  run_task send --from alice --chat test-chat --message "first"
+  run_task send --from alice --chat test-chat "first"
   [ "$status" -eq 0 ]
   mark_read "alice"
   send_message "bob" "unread"
 
-  run_task send --from alice --chat test-chat --message "forced" --force
+  run_task send --from alice --chat test-chat "forced" --force
   [ "$status" -eq 0 ]
   grep -q "forced" "$CHAT_FILE"
 }
@@ -189,7 +189,7 @@ load test_helper
   # bob has never read — cursor is 0
   send_message "carol" "some message"
   # bob should be able to send despite carol's unread message
-  run_task send --from bob --chat test-chat --message "hi from bob"
+  run_task send --from bob --chat test-chat "hi from bob"
   [ "$status" -eq 0 ]
 }
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -42,29 +42,13 @@ mark_read() {
   chat_set_cursor "$agent"
 }
 
-# Helper: run a task script with isolated env
+# Helper: run a task via mise with isolated env
 # Usage: run_task read --for alice --chat test-chat
-# Sets usage_* env vars from flags (mimics mise/usage parsing)
+# Passes CHAT_DATA_DIR and all flags through to `mise run`
 run_task() {
   local task="$1"
   shift
 
-  # Parse flags into usage_* env vars (mimics what mise does)
-  local -a env_vars=()
-  env_vars+=("CHAT_DATA_DIR=$CHAT_DATA_DIR")
-
-  while [ $# -gt 0 ]; do
-    case "$1" in
-      --for)    env_vars+=("usage_for=$2"); shift 2 ;;
-      --from)   env_vars+=("usage_from=$2"); shift 2 ;;
-      --chat)   env_vars+=("usage_chat=$2"); shift 2 ;;
-      --all)    env_vars+=("usage_all=true"); shift ;;
-      --mark-read) env_vars+=("usage_mark_read=true"); shift ;;
-      --force)  env_vars+=("usage_force=true"); shift ;;
-      --message) env_vars+=("usage_message=$2"); shift 2 ;;
-      *)        echo "run_task: unknown flag: $1" >&2; return 1 ;;
-    esac
-  done
-
-  run env "${env_vars[@]}" bash "$REPO_DIR/.mise/tasks/$task"
+  run env CHAT_DATA_DIR="$CHAT_DATA_DIR" \
+    mise run -C "$REPO_DIR" "$task" -- "$@"
 }


### PR DESCRIPTION
## Summary

Closes #9. Adds structured message access to chat — parse, query, filter, and merge channels programmatically.

- **`chat messages [channel]`** — list/filter messages by sender, date range; output as table or JSON with stable message IDs
- **`chat merge <source> <target>`** — interleave two channels by timestamp with source tags and cursor migration
- **`lib/parse.py`** — shared Python parser (Message dataclass: sender, timestamp, body, line_number, sha256-based stable ID)

### Notable

- **First Python+uv file tasks in KnickKnackLabs** — proves the PEP 723 inline dependency pattern with `#!/usr/bin/env -S uv run --script`
- **Refactored test helper** — `run_task` now uses `mise run` instead of calling scripts directly, so tests exercise the full mise stack (shebang dispatch, `#USAGE` parsing, env injection)
- Fixed existing send tests to pass message as positional arg (matching `#USAGE arg "<message>"`)

Depends on #10 (basename fix) being merged first.

## Test plan

- [x] 80/80 tests passing (`mise run test`)
- [x] 15 new tests covering messages (list, filter, JSON, IDs, empty, nonexistent) and merge (dry-run, actual merge, source tags, --no-tag, error cases, cursor reset/cleanup)
- [x] Successfully merged real `ricon-family-den` (226 msgs) + `den` (4 msgs) → `den` (230 msgs, correctly interleaved by timestamp)