### PR TITLE
feat: add bulk unread task

### DIFF
--- a/.mise/tasks/unread
+++ b/.mise/tasks/unread
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#MISE description="Count total unread messages across all channels"
+#USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
+#USAGE flag "--json" help="Output as JSON with per-channel breakdown"
+#USAGE flag "--max-parallel <max_parallel>" default=8 help="Max channels to check in parallel"
+set -eo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/chat.sh"
+
+chat_require_identity "${usage_as:-}"
+identity="$CHAT_IDENTITY"
+
+as_json="${usage_json:-false}"
+max_parallel="${usage_max_parallel:-8}"
+
+# List all channels
+channels=()
+for f in "$CHAT_DATA_DIR"/*.md; do
+  [ -f "$f" ] || continue
+  channels+=("$(basename "$f" .md)")
+done
+
+if [ ${#channels[@]} -eq 0 ]; then
+  [ "$as_json" = "true" ] && echo '{"total":0,"channels":{}}' || echo "0"
+  exit 0
+fi
+
+# Count unread per channel in parallel (bounded by max_parallel)
+RESULTS_DIR=$(mktemp -d)
+trap 'rm -rf "$RESULTS_DIR"' EXIT
+
+active=0
+for i in "${!channels[@]}"; do
+  name="${channels[$i]}"
+  (
+    CHAT_NAME="$name"
+    CHAT_FILE="$CHAT_DATA_DIR/${name}.md"
+    CHAT_CURSOR_DIR="$CHAT_DATA_DIR/.cursors/${name}"
+    count=$(chat_count_new "$identity")
+    echo -n "$count" > "$RESULTS_DIR/$i"
+  ) &
+  active=$((active + 1))
+  if [ "$active" -ge "$max_parallel" ]; then
+    wait -n 2>/dev/null || wait
+    active=$((active - 1))
+  fi
+done
+wait
+
+# Collect results
+total=0
+json_channels=""
+for i in "${!channels[@]}"; do
+  count=0
+  [ -f "$RESULTS_DIR/$i" ] && count=$(cat "$RESULTS_DIR/$i")
+  total=$((total + count))
+  if [ "$as_json" = "true" ] && [ "$count" -gt 0 ]; then
+    json_channels+="$(printf '"%s":%d,' "${channels[$i]}" "$count")"
+  fi
+done
+
+if [ "$as_json" = "true" ]; then
+  json_channels="${json_channels%,}"  # trim trailing comma
+  printf '{"total":%d,"channels":{%s}}\n' "$total" "$json_channels"
+else
+  [ "$total" -eq 0 ] && exit 0
+  echo "$total"
+fi

--- a/.mise/tasks/unread
+++ b/.mise/tasks/unread
@@ -2,7 +2,7 @@
 #MISE description="Count total unread messages across all channels"
 #USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
 #USAGE flag "--json" help="Output as JSON with per-channel breakdown"
-#USAGE flag "--max-parallel <max_parallel>" default=8 help="Max channels to check in parallel"
+#USAGE flag "--max-parallel <max_parallel>" default="8" help="Max channels to check in parallel"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"
@@ -21,47 +21,49 @@ for f in "$CHAT_DATA_DIR"/*.md; do
 done
 
 if [ ${#channels[@]} -eq 0 ]; then
-  [ "$as_json" = "true" ] && echo '{"total":0,"channels":{}}' || echo "0"
+  [ "$as_json" = "true" ] && echo '{"total":0,"channels":{}}'
   exit 0
 fi
 
-# Count unread per channel in parallel (bounded by max_parallel)
+# Count unread per channel in parallel (bounded by max_parallel).
+# Tracks PIDs explicitly for bash <4.3 compatibility (no wait -n).
 RESULTS_DIR=$(mktemp -d)
 trap 'rm -rf "$RESULTS_DIR"' EXIT
 
-active=0
+pids=()
 for i in "${!channels[@]}"; do
   name="${channels[$i]}"
   (
-    CHAT_NAME="$name"
-    CHAT_FILE="$CHAT_DATA_DIR/${name}.md"
-    CHAT_CURSOR_DIR="$CHAT_DATA_DIR/.cursors/${name}"
+    chat_resolve "$name"
     count=$(chat_count_new "$identity")
     echo -n "$count" > "$RESULTS_DIR/$i"
   ) &
-  active=$((active + 1))
-  if [ "$active" -ge "$max_parallel" ]; then
-    wait -n 2>/dev/null || wait
-    active=$((active - 1))
+  pids+=("$!")
+  if [ ${#pids[@]} -ge "$max_parallel" ]; then
+    wait "${pids[0]}" 2>/dev/null || true
+    pids=("${pids[@]:1}")
   fi
 done
 wait
 
 # Collect results
 total=0
-json_channels=""
+json_pairs=()
 for i in "${!channels[@]}"; do
   count=0
   [ -f "$RESULTS_DIR/$i" ] && count=$(cat "$RESULTS_DIR/$i")
   total=$((total + count))
   if [ "$as_json" = "true" ] && [ "$count" -gt 0 ]; then
-    json_channels+="$(printf '"%s":%d,' "${channels[$i]}" "$count")"
+    json_pairs+=("$(jq -n --arg n "${channels[$i]}" --argjson c "$count" '{($n):$c}')")
   fi
 done
 
 if [ "$as_json" = "true" ]; then
-  json_channels="${json_channels%,}"  # trim trailing comma
-  printf '{"total":%d,"channels":{%s}}\n' "$total" "$json_channels"
+  channels_obj="{}"
+  for pair in "${json_pairs[@]+${json_pairs[@]}}"; do
+    channels_obj=$(echo "$channels_obj" "$pair" | jq -s '.[0] * .[1]')
+  done
+  jq -n --argjson total "$total" --argjson channels "$channels_obj" '{total: $total, channels: $channels}'
 else
   [ "$total" -eq 0 ] && exit 0
   echo "$total"

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -667,3 +667,89 @@ names = [c['name'] for c in json.load(sys.stdin)]
 assert 'test-chat' not in names, f'test-chat should be gone, got {names}'
 "
 }
+
+# ============================================================================
+# unread task
+# ============================================================================
+
+@test "task unread: zero total exits 0 with no output" {
+  mark_read "alice"
+  run chat unread --as alice
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "task unread: zero total JSON returns structured response" {
+  mark_read "alice"
+  run chat unread --as alice --json
+  [ "$status" -eq 0 ]
+  total=$(echo "$output" | jq '.total')
+  [ "$total" -eq 0 ]
+  channels=$(echo "$output" | jq '.channels | length')
+  [ "$channels" -eq 0 ]
+}
+
+@test "task unread: sums across channels" {
+  # Create a second channel
+  CHAT_NAME="other-chat"
+  CHAT_FILE="$CHAT_DATA_DIR/other-chat.md"
+  CHAT_CURSOR_DIR="$CHAT_DATA_DIR/.cursors/other-chat"
+  chat_init
+
+  # Mark both as read, then send messages
+  chat_resolve "test-chat"
+  mark_read "alice"
+  send_message "bob" "msg1"
+  send_message "bob" "msg2"
+
+  chat_resolve "other-chat"
+  mark_read "alice"
+  send_message "carol" "msg3"
+
+  run chat unread --as alice
+  [ "$status" -eq 0 ]
+  [ "$output" = "3" ]
+}
+
+@test "task unread: excludes own messages" {
+  mark_read "alice"
+  send_message "alice" "my own message"
+  send_message "bob" "from bob"
+  run chat unread --as alice
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}
+
+@test "task unread: JSON shows per-channel breakdown" {
+  # Create a second channel
+  CHAT_NAME="other-chat"
+  CHAT_FILE="$CHAT_DATA_DIR/other-chat.md"
+  CHAT_CURSOR_DIR="$CHAT_DATA_DIR/.cursors/other-chat"
+  chat_init
+
+  chat_resolve "test-chat"
+  mark_read "alice"
+  send_message "bob" "msg1"
+
+  chat_resolve "other-chat"
+  mark_read "alice"
+  send_message "carol" "msg2"
+  send_message "carol" "msg3"
+
+  run chat unread --as alice --json
+  [ "$status" -eq 0 ]
+  total=$(echo "$output" | jq '.total')
+  [ "$total" -eq 3 ]
+  test_count=$(echo "$output" | jq '.channels["test-chat"]')
+  [ "$test_count" -eq 1 ]
+  other_count=$(echo "$output" | jq '.channels["other-chat"]')
+  [ "$other_count" -eq 2 ]
+}
+
+@test "task unread: no channels exits 0" {
+  # Remove all chat files
+  rm -f "$CHAT_DATA_DIR"/*.md
+  run chat unread --as alice
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
Single `chat unread` invocation counts unread messages across all channels in parallel (bounded by `--max-parallel`, default 8). Supports `--json` for per-channel breakdown.

**Motivation:** The dashboard's unread-chat provider was calling `chat list` + `chat read --peek --json` per channel — 6 invocations at ~300ms each = ~1.8s. Now a single `chat unread` call takes ~340ms.

**Depends on:** nothing (standalone)
**Depended on by:** KnickKnackLabs/escort feat/bulk-unread-chat