### PR TITLE
fix(unread): reap final parallel workers explicitly

### DIFF
--- a/.mise/tasks/unread
+++ b/.mise/tasks/unread
@@ -48,7 +48,12 @@ for i in "${!channels[@]}"; do
     pids=("${pids[@]:1}")
   fi
 done
-wait
+
+for pid in "${pids[@]}"; do
+  if ! wait "$pid" 2>/dev/null; then
+    :
+  fi
+done
 
 # Collect results
 total=0


### PR DESCRIPTION
Fix-it for #35.\n\nThe bounded-parallel reap now intentionally ignores per-channel worker failures, but the trailing bare `wait` still let failures from the final batch affect the task exit. This reaps the remaining PIDs with the same explicit `if ! wait ...; then : fi` shape.\n\nVerification:\n- `codebase lint:or-true .`\n- `codebase lint:shellcheck .`\n- `mise run test --filter 'task unread'`