### PR TITLE
Use default chat channel without repo detection

### DIFF
--- a/.mise/tasks/clear
+++ b/.mise/tasks/clear
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Archive old messages and reset a chat"
-#USAGE arg "[chat]" help="Chat name (default: auto-detect from git remote)"
+#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--yes" help="Skip confirmation"
 set -eo pipefail
 

--- a/.mise/tasks/cursor/clear
+++ b/.mise/tasks/cursor/clear
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Clear your cursor (mark everything as unread)"
-#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or auto-detect)"
+#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
 set -eo pipefail
 

--- a/.mise/tasks/list
+++ b/.mise/tasks/list
@@ -47,9 +47,8 @@ if ! compgen -G "$CHAT_DATA_DIR/*.md" >/dev/null 2>&1; then
   exit 0
 fi
 
-# Detect current chat for marker
-current=$(_chat_detect_repo)
-current="${current:-global}"
+# Mark the channel that an implicit command would target.
+current="${CHAT_CHANNEL:-default}"
 
 show_all="${usage_all:-false}"
 

--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Read messages"
-#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or auto-detect)"
+#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
 #USAGE flag "--peek" help="Don't advance cursor (just look)"
 #USAGE flag "--all" help="Show all messages, not just unread"

--- a/.mise/tasks/readme
+++ b/.mise/tasks/readme
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Regenerate README.md from README.tsx"
+#MISE hide=true
+set -euo pipefail
+
+cd "$MISE_CONFIG_ROOT"
+readme build

--- a/.mise/tasks/remove
+++ b/.mise/tasks/remove
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Permanently remove a chat channel"
-#USAGE arg "[chat]" help="Chat name (default: auto-detect from git remote)"
+#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--yes" help="Skip confirmation"
 set -eo pipefail
 
@@ -8,8 +8,8 @@ source "$MISE_CONFIG_ROOT/lib/chat.sh"
 chat_resolve "${usage_chat:-}"
 chat_require_file
 
-if [ "$CHAT_NAME" = "global" ]; then
-  echo "Error: cannot remove the global channel." >&2
+if [ "$CHAT_NAME" = "default" ] || [ "$CHAT_NAME" = "global" ]; then
+  echo "Error: cannot remove the ${CHAT_NAME} channel." >&2
   exit 1
 fi
 

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Send a message to a chat"
 #USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
-#USAGE flag "--chat <chat>" help="Chat name (default: $CHAT_CHANNEL or auto-detect)"
+#USAGE flag "--chat <chat>" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "-f --force" help="Send even if there are unread messages"
 #USAGE arg "<message>" help="The message to send (or - for stdin)"
 set -eo pipefail

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Chat status overview"
-#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or auto-detect)"
+#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--as <as>" help="Your identity — shows unread count (default: $CHAT_IDENTITY)"
 #USAGE flag "--json" help="Output as JSON object"
 set -eo pipefail

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Wait for a new message"
-#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or auto-detect)"
+#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--as <as>" help="Your identity — ignores own messages (default: $CHAT_IDENTITY)"
 #USAGE flag "--timeout <seconds>" help="Max seconds to wait (0 = forever)" default="120"
 #USAGE flag "--forever" help="Wait indefinitely (shorthand for --timeout 0)"

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Archive old messages and reset a chat
 chat clear [--yes] [chat]
 ```
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--yes` | Skip confirmation | — |
+| Flag    | Description       | Default |
+| ------- | ----------------- | ------- |
+| `--yes` | Skip confirmation | —       |
 
 
 ### chat list
@@ -114,12 +114,12 @@ List available chats
 chat list [--json] [--all] [--unread] [--as <as>]
 ```
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--json` | Output as JSON array | — |
-| `--all` | Include empty channels (hidden by default) | — |
-| `--unread` | Only list channels with unread messages (requires identity) | — |
-| `--as` | Your identity (default: $CHAT_IDENTITY). When set, an Unread column is shown. | — |
+| Flag       | Description                                                                   | Default |
+| ---------- | ----------------------------------------------------------------------------- | ------- |
+| `--json`   | Output as JSON array                                                          | —       |
+| `--all`    | Include empty channels (hidden by default)                                    | —       |
+| `--unread` | Only list channels with unread messages (requires identity)                   | —       |
+| `--as`     | Your identity (default: $CHAT_IDENTITY). When set, an Unread column is shown. | —       |
 
 
 ### chat merge
@@ -130,10 +130,10 @@ Merge two chat channels by interleaving messages by timestamp
 chat merge [--dry-run] [--no-tag] <source> <target>
 ```
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--dry-run` | Show what would happen without writing | — |
-| `--no-tag` | Don't annotate messages with source channel | — |
+| Flag        | Description                                 | Default |
+| ----------- | ------------------------------------------- | ------- |
+| `--dry-run` | Show what would happen without writing      | —       |
+| `--no-tag`  | Don't annotate messages with source channel | —       |
 
 
 ### chat read
@@ -144,17 +144,17 @@ Read messages
 chat read [--as <as>] [--peek] [--all] [--last <last>] [--from <from>] [--after <after>] [--before <before>] [--json] [--id] [chat]
 ```
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--as` | Your identity (default: $CHAT_IDENTITY) | — |
-| `--peek` | Don't advance cursor (just look) | — |
-| `--all` | Show all messages, not just unread | — |
-| `--last` | Show only the last N messages (of unread, or of all with --all) | — |
-| `--from` | Filter messages by sender | — |
-| `--after` | Show messages after this date (YYYY-MM-DD) | — |
-| `--before` | Show messages before this date (YYYY-MM-DD) | — |
-| `--json` | Output as JSON array | — |
-| `--id` | Include message IDs in JSON output | — |
+| Flag       | Description                                                     | Default |
+| ---------- | --------------------------------------------------------------- | ------- |
+| `--as`     | Your identity (default: $CHAT_IDENTITY)                         | —       |
+| `--peek`   | Don't advance cursor (just look)                                | —       |
+| `--all`    | Show all messages, not just unread                              | —       |
+| `--last`   | Show only the last N messages (of unread, or of all with --all) | —       |
+| `--from`   | Filter messages by sender                                       | —       |
+| `--after`  | Show messages after this date (YYYY-MM-DD)                      | —       |
+| `--before` | Show messages before this date (YYYY-MM-DD)                     | —       |
+| `--json`   | Output as JSON array                                            | —       |
+| `--id`     | Include message IDs in JSON output                              | —       |
 
 
 ### chat remove
@@ -165,9 +165,9 @@ Permanently remove a chat channel
 chat remove [--yes] [chat]
 ```
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--yes` | Skip confirmation | — |
+| Flag    | Description       | Default |
+| ------- | ----------------- | ------- |
+| `--yes` | Skip confirmation | —       |
 
 
 ### chat send
@@ -178,11 +178,11 @@ Send a message to a chat
 chat send [--as <as>] [--chat <chat>] [-f, --force] <message>
 ```
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--as` | Your identity (default: $CHAT_IDENTITY) | — |
-| `--chat` | Chat name (default: $CHAT_CHANNEL or default) | — |
-| `-f, --force` | Send even if there are unread messages | — |
+| Flag          | Description                                   | Default |
+| ------------- | --------------------------------------------- | ------- |
+| `--as`        | Your identity (default: $CHAT_IDENTITY)       | —       |
+| `--chat`      | Chat name (default: $CHAT_CHANNEL or default) | —       |
+| `-f, --force` | Send even if there are unread messages        | —       |
 
 
 ### chat status
@@ -193,10 +193,10 @@ Chat status overview
 chat status [--as <as>] [--json] [chat]
 ```
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--as` | Your identity — shows unread count (default: $CHAT_IDENTITY) | — |
-| `--json` | Output as JSON object | — |
+| Flag     | Description                                                  | Default |
+| -------- | ------------------------------------------------------------ | ------- |
+| `--as`   | Your identity — shows unread count (default: $CHAT_IDENTITY) | —       |
+| `--json` | Output as JSON object                                        | —       |
 
 
 ### chat test
@@ -216,10 +216,10 @@ Count total unread messages across all channels
 chat unread [--as <as>] [--json]
 ```
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--as` | Your identity (default: $CHAT_IDENTITY) | — |
-| `--json` | Output as JSON with per-channel breakdown | — |
+| Flag     | Description                               | Default |
+| -------- | ----------------------------------------- | ------- |
+| `--as`   | Your identity (default: $CHAT_IDENTITY)   | —       |
+| `--json` | Output as JSON with per-channel breakdown | —       |
 
 
 ### chat wait
@@ -230,12 +230,12 @@ Wait for a new message
 chat wait [--as <as>] [--timeout <seconds>] [--forever] [--batch <batch>] [chat]
 ```
 
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--as` | Your identity — ignores own messages (default: $CHAT_IDENTITY) | — |
-| `--timeout` | Max seconds to wait (0 = forever) | `120` |
-| `--forever` | Wait indefinitely (shorthand for --timeout 0) | — |
-| `--batch` | Wait for N messages from others before waking (default: 1) | `1` |
+| Flag        | Description                                                    | Default |
+| ----------- | -------------------------------------------------------------- | ------- |
+| `--as`      | Your identity — ignores own messages (default: $CHAT_IDENTITY) | —       |
+| `--timeout` | Max seconds to wait (0 = forever)                              | `120`   |
+| `--forever` | Wait indefinitely (shorthand for --timeout 0)                  | —       |
+| `--batch`   | Wait for N messages from others before waking (default: 1)     | `1`     |
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agents on the same machine exchange short messages through a shared channel.
 No server. No daemon. Just files, cursors, and bash.
 
 ![lang: bash](https://img.shields.io/badge/lang-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 89 passing](https://img.shields.io/badge/tests-89%20passing-brightgreen?style=flat)](test/)
+[![tests: 149 passing](https://img.shields.io/badge/tests-149%20passing-brightgreen?style=flat)](test/)
 ![deps: jq + gum](https://img.shields.io/badge/deps-jq%20%2B%20gum-blue?style=flat)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)
 
@@ -90,7 +90,7 @@ FYI — just pushed the load testing scenarios to the note.
 
 ## Commands
 
-**7 commands**, each a standalone bash script in `.mise/tasks/`:
+**10 commands**, each a standalone bash script in `.mise/tasks/`:
 
 
 ### chat clear
@@ -98,12 +98,11 @@ FYI — just pushed the load testing scenarios to the note.
 Archive old messages and reset a chat
 
 ```
-chat clear [--chat <chat>] [--yes]
+chat clear [--yes] [chat]
 ```
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--chat` | Chat name (default: auto-detect from git remote) | — |
 | `--yes` | Skip confirmation | — |
 
 
@@ -112,8 +111,15 @@ chat clear [--chat <chat>] [--yes]
 List available chats
 
 ```
-chat list
+chat list [--json] [--all] [--unread] [--as <as>]
 ```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--json` | Output as JSON array | — |
+| `--all` | Include empty channels (hidden by default) | — |
+| `--unread` | Only list channels with unread messages (requires identity) | — |
+| `--as` | Your identity (default: $CHAT_IDENTITY). When set, an Unread column is shown. | — |
 
 
 ### chat merge
@@ -135,13 +141,12 @@ chat merge [--dry-run] [--no-tag] <source> <target>
 Read messages
 
 ```
-chat read [--as <as>] [--chat <chat>] [--peek] [--all] [--last <last>] [--from <from>] [--after <after>] [--before <before>] [--json] [--id]
+chat read [--as <as>] [--peek] [--all] [--last <last>] [--from <from>] [--after <after>] [--before <before>] [--json] [--id] [chat]
 ```
 
 | Flag | Description | Default |
 | --- | --- | --- |
 | `--as` | Your identity (default: $CHAT_IDENTITY) | — |
-| `--chat` | Chat name (default: $CHAT_CHANNEL or auto-detect) | — |
 | `--peek` | Don't advance cursor (just look) | — |
 | `--all` | Show all messages, not just unread | — |
 | `--last` | Show only the last N messages (of unread, or of all with --all) | — |
@@ -150,6 +155,19 @@ chat read [--as <as>] [--chat <chat>] [--peek] [--all] [--last <last>] [--from <
 | `--before` | Show messages before this date (YYYY-MM-DD) | — |
 | `--json` | Output as JSON array | — |
 | `--id` | Include message IDs in JSON output | — |
+
+
+### chat remove
+
+Permanently remove a chat channel
+
+```
+chat remove [--yes] [chat]
+```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--yes` | Skip confirmation | — |
 
 
 ### chat send
@@ -163,7 +181,7 @@ chat send [--as <as>] [--chat <chat>] [-f, --force] <message>
 | Flag | Description | Default |
 | --- | --- | --- |
 | `--as` | Your identity (default: $CHAT_IDENTITY) | — |
-| `--chat` | Chat name (default: $CHAT_CHANNEL or auto-detect) | — |
+| `--chat` | Chat name (default: $CHAT_CHANNEL or default) | — |
 | `-f, --force` | Send even if there are unread messages | — |
 
 
@@ -172,13 +190,36 @@ chat send [--as <as>] [--chat <chat>] [-f, --force] <message>
 Chat status overview
 
 ```
-chat status [--as <as>] [--chat <chat>]
+chat status [--as <as>] [--json] [chat]
 ```
 
 | Flag | Description | Default |
 | --- | --- | --- |
 | `--as` | Your identity — shows unread count (default: $CHAT_IDENTITY) | — |
-| `--chat` | Chat name (default: $CHAT_CHANNEL or auto-detect) | — |
+| `--json` | Output as JSON object | — |
+
+
+### chat test
+
+Run BATS test suite
+
+```
+chat test
+```
+
+
+### chat unread
+
+Count total unread messages across all channels
+
+```
+chat unread [--as <as>] [--json]
+```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--as` | Your identity (default: $CHAT_IDENTITY) | — |
+| `--json` | Output as JSON with per-channel breakdown | — |
 
 
 ### chat wait
@@ -186,14 +227,15 @@ chat status [--as <as>] [--chat <chat>]
 Wait for a new message
 
 ```
-chat wait [--as <as>] [--chat <chat>] [--timeout <seconds>]
+chat wait [--as <as>] [--timeout <seconds>] [--forever] [--batch <batch>] [chat]
 ```
 
 | Flag | Description | Default |
 | --- | --- | --- |
 | `--as` | Your identity — ignores own messages (default: $CHAT_IDENTITY) | — |
-| `--chat` | Chat name (default: $CHAT_CHANNEL or auto-detect) | — |
 | `--timeout` | Max seconds to wait (0 = forever) | `120` |
+| `--forever` | Wait indefinitely (shorthand for --timeout 0) | — |
+| `--batch` | Wait for N messages from others before waking (default: 1) | `1` |
 
 <br />
 
@@ -209,14 +251,13 @@ Commands that need to know who you are use a single resolution chain:
 
 ## Channel resolution
 
-When you don't pass `--chat`, the tool figures out which channel to use:
+When you don't pass `--chat`, the tool uses a small, predictable resolution chain:
 
 1. **Explicit** — `--chat myproject` selects a specific channel
 2. **Environment** — `$CHAT_CHANNEL` env var (useful in CI or agent homes)
-3. **Git remote** — auto-detects from the current repo's origin (e.g. `ricon-family/den` → `den`)
-4. **Global fallback** — defaults to `global` if nothing else matches
+3. **Default** — otherwise commands use the literal `default` channel
 
-Agents working in the same repo automatically share a channel — no configuration needed.
+Git repository names are not used for implicit channel selection. Use `--chat fold` or set `CHAT_CHANNEL=fold` when you want a repo-specific channel.
 
 ## Design
 
@@ -280,7 +321,7 @@ cd chat && mise trust && mise install
 mise run test
 ```
 
-89 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
+149 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
 
 <br />
 

--- a/README.tsx
+++ b/README.tsx
@@ -23,7 +23,7 @@ interface Command {
   name: string;
   description: string;
   flags: { name: string; shortFlag?: string; valueName?: string; help: string; required?: boolean; default?: string; isBoolean: boolean }[];
-  args: { name: string; help: string }[];
+  args: { name: string; help: string; optional: boolean }[];
   hidden: boolean;
 }
 
@@ -52,9 +52,9 @@ function parseTask(filename: string): Command {
       flags.push({ name: `--${name}`, shortFlag, valueName, help, required: required || undefined, default: defMatch?.[1], isBoolean: !valueName });
     }
 
-    const argMatch = line.match(/#USAGE arg "<(\w+)>" help="([^"]+)"/);
+    const argMatch = line.match(/#USAGE arg "([<\[])(\w+)([>\]])" help="([^"]+)"/);
     if (argMatch) {
-      args.push({ name: argMatch[1], help: argMatch[2] });
+      args.push({ name: argMatch[2], help: argMatch[4], optional: argMatch[1] === "[" });
     }
   }
 
@@ -62,7 +62,9 @@ function parseTask(filename: string): Command {
 }
 
 // Parse all tasks
-const taskFiles = readdirSync(TASK_DIR).filter(f => !f.startsWith(".") && !f.startsWith("_"));
+const taskFiles = readdirSync(TASK_DIR, { withFileTypes: true })
+  .filter(entry => entry.isFile() && !entry.name.startsWith(".") && !entry.name.startsWith("_"))
+  .map(entry => entry.name);
 const commands = taskFiles
   .map(parseTask)
   .filter(c => !c.hidden)
@@ -124,7 +126,7 @@ function cmdUsage(cmd: Command): string {
     parts.push(f.required ? `${flagName}${val}` : `[${flagName}${val}]`);
   }
   for (const a of cmd.args) {
-    parts.push(`<${a.name}>`);
+    parts.push(a.optional ? `[${a.name}]` : `<${a.name}>`);
   }
   return parts.join(" ");
 }
@@ -268,18 +270,21 @@ chat status`}</CodeBlock>
       <Paragraph>
         {"When you don't pass "}
         <Code>--chat</Code>
-        {", the tool figures out which channel to use:"}
+        {", the tool uses a small, predictable resolution chain:"}
       </Paragraph>
 
       <List ordered>
         <Item><Bold>Explicit</Bold>{" — "}<Code>--chat myproject</Code>{" selects a specific channel"}</Item>
         <Item><Bold>Environment</Bold>{" — "}<Code>$CHAT_CHANNEL</Code>{" env var (useful in CI or agent homes)"}</Item>
-        <Item><Bold>Git remote</Bold>{" — auto-detects from the current repo's origin (e.g. "}<Code>ricon-family/den</Code>{" → "}<Code>den</Code>{")"}</Item>
-        <Item><Bold>Global fallback</Bold>{" — defaults to "}<Code>global</Code>{" if nothing else matches"}</Item>
+        <Item><Bold>Default</Bold>{" — otherwise commands use the literal "}<Code>default</Code>{" channel"}</Item>
       </List>
 
       <Paragraph>
-        {"Agents working in the same repo automatically share a channel — no configuration needed."}
+        {"Git repository names are not used for implicit channel selection. Use "}
+        <Code>--chat fold</Code>
+        {" or set "}
+        <Code>CHAT_CHANNEL=fold</Code>
+        {" when you want a repo-specific channel."}
       </Paragraph>
     </Section>
 

--- a/lib/chat.sh
+++ b/lib/chat.sh
@@ -25,24 +25,8 @@ chat_require_identity() {
   fi
 }
 
-# Detect chat name from git remote origin of the caller's directory
-# Returns the repo name (last path component, no org prefix) or empty
-# string when the caller isn't inside a git repo. Always exits 0.
-_chat_detect_repo() {
-  local dir="${CALLER_PWD:-$PWD}"
-  local url
-  if ! url=$(git -C "$dir" remote get-url origin 2>/dev/null); then
-    return 0
-  fi
-  # Strip protocol, host, .git suffix → org/repo, then take last component
-  local path
-  path=$(echo "$url" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##; s/\.git$//')
-  [ -n "$path" ] && basename "$path"
-  return 0
-}
-
-# Resolve which chat we're targeting
-# Priority: explicit name > $CHAT_CHANNEL env var > git repo > "global"
+# Resolve which chat we're targeting.
+# Priority: explicit name > $CHAT_CHANNEL env var > "default"
 # Usage: chat_resolve [name]
 # Sets CHAT_NAME, CHAT_FILE, CHAT_CURSOR_DIR
 chat_resolve() {
@@ -51,8 +35,7 @@ chat_resolve() {
   elif [ -n "${CHAT_CHANNEL:-}" ]; then
     CHAT_NAME="$CHAT_CHANNEL"
   else
-    CHAT_NAME=$(_chat_detect_repo)
-    CHAT_NAME="${CHAT_NAME:-global}"
+    CHAT_NAME="default"
   fi
   CHAT_FILE="$CHAT_DATA_DIR/${CHAT_NAME}.md"
   CHAT_CURSOR_DIR="$CHAT_DATA_DIR/.cursors/${CHAT_NAME}"

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ gum = "latest"
 uv = "latest"
 bats = "1.13.0"
 "shiv:codebase" = "0.2.0"                  # Codebase linting + migrations
-"shiv:readme" = "latest"
+"shiv:readme" = "0.1.1"
 
 [_.codebase]
 lint = ["mise-settings", "gum-table", "bats-test-helper", "bats-test-task", "mcr-scope", "or-true", "shellcheck"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,10 @@
 [settings]
+experimental = true
 quiet = true
 task_output = "interleave"
+
+[plugins]
+shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
 jq = "latest"
@@ -8,6 +12,7 @@ gum = "latest"
 uv = "latest"
 bats = "1.13.0"
 "shiv:codebase" = "0.2.0"                  # Codebase linting + migrations
+"shiv:readme" = "latest"
 
 [_.codebase]
 lint = ["mise-settings", "gum-table", "bats-test-helper", "bats-test-task", "mcr-scope", "or-true", "shellcheck"]

--- a/test/chat_lib.bats
+++ b/test/chat_lib.bats
@@ -22,9 +22,8 @@ load test_helper
   [ "$CHAT_CURSOR_DIR" = "$CHAT_DATA_DIR/.cursors/my-chat" ]
 }
 
-@test "resolve: CHAT_CHANNEL env var takes priority over git remote" {
-  _setup_git_remote "https://github.com/org/repo.git"
-  CHAT_CHANNEL="from-env" CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+@test "resolve: CHAT_CHANNEL env var takes priority over default" {
+  CHAT_CHANNEL="from-env" chat_resolve ""
   [ "$CHAT_NAME" = "from-env" ]
 }
 
@@ -33,10 +32,15 @@ load test_helper
   [ "$CHAT_NAME" = "explicit" ]
 }
 
-@test "resolve: empty name falls back to global" {
-  # No git repo in BATS_TMPDIR, so falls back
-  CALLER_PWD="$BATS_TMPDIR" chat_resolve ""
-  [ "$CHAT_NAME" = "global" ]
+@test "resolve: empty name falls back to default" {
+  chat_resolve ""
+  [ "$CHAT_NAME" = "default" ]
+}
+
+@test "resolve: package caller-pwd context is ignored when no chat/channel is set" {
+  _setup_git_remote "https://github.com/ricon-family/fold.git"
+  CHAT_CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
+  [ "$CHAT_NAME" = "default" ]
 }
 
 # ============================================================================
@@ -82,66 +86,6 @@ load test_helper
   export CHAT_IDENTITY="alice"
   run chat_require_identity ""
   [ "$status" -eq 0 ]
-}
-
-# ============================================================================
-# _chat_detect_repo — git remote auto-detection
-# ============================================================================
-
-@test "detect_repo: extracts repo name from HTTPS remote" {
-  _setup_git_remote "https://github.com/ricon-family/den.git"
-  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
-  [ "$CHAT_NAME" = "den" ]
-}
-
-@test "detect_repo: extracts repo name from SSH remote" {
-  _setup_git_remote "git@github.com:KnickKnackLabs/chat.git"
-  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
-  [ "$CHAT_NAME" = "chat" ]
-}
-
-@test "detect_repo: extracts repo name from GHE HTTPS remote" {
-  _setup_git_remote "https://gecgithub01.walmart.com/Torbit/okwai.git"
-  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
-  [ "$CHAT_NAME" = "okwai" ]
-}
-
-@test "detect_repo: strips .git suffix" {
-  _setup_git_remote "https://github.com/org/myrepo.git"
-  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
-  [ "$CHAT_NAME" = "myrepo" ]
-}
-
-@test "detect_repo: works without .git suffix" {
-  _setup_git_remote "https://github.com/org/myrepo"
-  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
-  [ "$CHAT_NAME" = "myrepo" ]
-}
-
-@test "detect_repo: no-org remote still works" {
-  _setup_git_remote "https://github.com/solo-repo.git"
-  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
-  [ "$CHAT_NAME" = "solo-repo" ]
-}
-
-@test "detect_repo: falls back to global when no git repo" {
-  CALLER_PWD="$BATS_TEST_TMPDIR" chat_resolve ""
-  [ "$CHAT_NAME" = "global" ]
-}
-
-@test "detect_repo: different orgs same repo name resolve to same channel" {
-  # This is intentional — shared name = shared channel
-  _setup_git_remote "https://github.com/org-a/shared.git"
-  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
-  local name_a="$CHAT_NAME"
-
-  # Reset and set up a different org
-  _setup_git_remote "https://github.com/org-b/shared.git"
-  CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo" chat_resolve ""
-  local name_b="$CHAT_NAME"
-
-  [ "$name_a" = "$name_b" ]
-  [ "$name_a" = "shared" ]
 }
 
 # ============================================================================

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -77,6 +77,18 @@ load test_helper
   [[ "$output" == *"env-identity test"* ]]
 }
 
+@test "task read: no chat argument ignores package caller-pwd context" {
+  _setup_git_remote "https://github.com/KnickKnackLabs/chat.git"
+  chat_resolve "default"
+  chat_init
+  chat_append "bob" "default-channel message"
+
+  export CHAT_CALLER_PWD="$BATS_TEST_TMPDIR/fakerepo"
+  run chat read --as alice --all
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"default-channel message"* ]]
+}
+
 @test "task read: --from filters by sender" {
   mark_read "alice"
   send_message "bob" "from bob"
@@ -766,14 +778,21 @@ assert 'unread' not in data, f'unread should not be present without --as, got: {
   [[ "$output" == *"does not exist"* ]]
 }
 
-@test "task remove: refuses to remove global channel" {
-  # Create the global channel
+@test "task remove: refuses to remove default channel" {
+  chat_resolve "default"
+  chat_init
+  run chat remove default --yes
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot remove the default channel"* ]]
+  [ -f "$CHAT_DATA_DIR/default.md" ]
+}
+
+@test "task remove: refuses to remove legacy global channel" {
   chat_resolve "global"
   chat_init
   run chat remove global --yes
   [ "$status" -ne 0 ]
   [[ "$output" == *"cannot remove the global channel"* ]]
-  # File should still exist
   [ -f "$CHAT_DATA_DIR/global.md" ]
 }
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -17,6 +17,7 @@ setup() {
   # Clear env vars that could leak between tests
   unset CHAT_IDENTITY
   unset CHAT_CHANNEL
+  unset CHAT_CALLER_PWD
 
   source "$CHAT_REPO_ROOT/lib/chat.sh"
   chat_resolve "test-chat"


### PR DESCRIPTION
## Summary

- Replace implicit git-repo channel detection with a literal `default` channel.
- Keep explicit chat args and `CHAT_CHANNEL` as the only overrides.
- Remove caller-cwd usage from chat channel resolution; `CHAT_CALLER_PWD` is ignored for channel selection.
- Add a hidden README regeneration task and pin `shiv:readme = 0.1.1` so README generation is deterministic.

Closes #37.

## Verification

- `mise run test` (149/149)
- `find .mise/tasks -type f -print0 | xargs -0 bash -n`
- `bash -n lib/chat.sh test/test_helper.bash`
- `mise exec -- readme build --check`
- `git diff --check`
- codebase lints: `lint:mise-settings`, `lint:gum-table`, `lint:bats-test-helper`, `lint:bats-test-task`, `lint:mcr-scope`, `lint:or-true`, `lint:shellcheck`
