### PR TITLE
feat(#28): add per-identity signatures

### DIFF
--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -39,6 +39,15 @@ if [ "$line_count" -gt "$MAX_LINES" ]; then
   exit 1
 fi
 
+# Append signature if set (after line-count check so limit applies to message only)
+sig_file="$CHAT_DATA_DIR/.signatures/$from"
+if [ -f "$sig_file" ]; then
+  message="${message}
+
+--
+$(cat "$sig_file")"
+fi
+
 # Guard: warn if sender has unread messages (skip for first-time senders)
 if [ "${usage_force:-false}" != "true" ]; then
   cursor=$(chat_get_cursor "$from")

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Send a message to a chat"
-#USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
-#USAGE flag "--chat <chat>" help="Chat name (default: $CHAT_CHANNEL or default)"
-#USAGE flag "-f --force" help="Send even if there are unread messages"
+#USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)" default=""
+#USAGE flag "--chat <chat>" help="Chat name (default: $CHAT_CHANNEL or default)" default=""
+#USAGE flag "-f --force" help="Send even if there are unread messages" default=#false
 #USAGE arg "<message>" help="The message to send (or - for stdin)"
 #USAGE example "chat send --as alice 'hello everyone'" header="Send a message as alice"
 #USAGE example "chat send --chat ops --as alice 'deploying now'" header="Send to a specific chat"

--- a/.mise/tasks/sig
+++ b/.mise/tasks/sig
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#MISE description="Manage your message signature"
+#USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
+#USAGE flag "--clear" help="Remove your signature"
+#USAGE arg "[signature]" help="Signature text to set (omit to show current)"
+#USAGE example "chat sig --as alice 'sent from pi'" header="Set alice's signature"
+#USAGE example "chat sig --as alice" header="Show alice's current signature"
+#USAGE example "chat sig --as alice --clear" header="Remove alice's signature"
+set -eo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/chat.sh"
+
+chat_require_identity "${usage_as:-}"
+identity="$CHAT_IDENTITY"
+
+sig_dir="$CHAT_DATA_DIR/.signatures"
+sig_file="$sig_dir/$identity"
+
+if [ "${usage_clear:-false}" = "true" ]; then
+  if [ -f "$sig_file" ]; then
+    rm "$sig_file"
+    echo "Signature cleared for ${identity}."
+  else
+    echo "No signature set for ${identity}."
+  fi
+  exit 0
+fi
+
+if [ -n "${usage_signature:-}" ]; then
+  mkdir -p "$sig_dir"
+  printf '%s' "${usage_signature}" > "$sig_file"
+  echo "Signature set for ${identity}."
+  exit 0
+fi
+
+# Show current signature
+if [ -f "$sig_file" ]; then
+  echo "Signature for ${identity}:"
+  echo ""
+  cat "$sig_file"
+else
+  echo "No signature set for ${identity}."
+fi

--- a/.mise/tasks/sig
+++ b/.mise/tasks/sig
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Manage your message signature"
-#USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
-#USAGE flag "--clear" help="Remove your signature"
-#USAGE arg "[signature]" help="Signature text to set (omit to show current)"
+#USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)" default=""
+#USAGE flag "--clear" help="Remove your signature" default=#false
+#USAGE arg "[signature]" help="Signature text to set (omit to show current)" default=""
 #USAGE example "chat sig --as alice 'sent from pi'" header="Set alice's signature"
 #USAGE example "chat sig --as alice" header="Show alice's current signature"
 #USAGE example "chat sig --as alice --clear" header="Remove alice's signature"
@@ -15,6 +15,12 @@ identity="$CHAT_IDENTITY"
 
 sig_dir="$CHAT_DATA_DIR/.signatures"
 sig_file="$sig_dir/$identity"
+signature="${usage_signature:-}"
+
+if [ "${usage_clear:-false}" = "true" ] && [ -n "$signature" ]; then
+  echo "Error: provide a signature to set, or --clear to remove it, not both." >&2
+  exit 1
+fi
 
 if [ "${usage_clear:-false}" = "true" ]; then
   if [ -f "$sig_file" ]; then
@@ -26,9 +32,9 @@ if [ "${usage_clear:-false}" = "true" ]; then
   exit 0
 fi
 
-if [ -n "${usage_signature:-}" ]; then
+if [ -n "$signature" ]; then
   mkdir -p "$sig_dir"
-  printf '%s' "${usage_signature}" > "$sig_file"
+  printf '%s' "$signature" > "$sig_file"
   echo "Signature set for ${identity}."
   exit 0
 fi

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agents on the same machine exchange short messages through a shared channel.
 No server. No daemon. Just files, cursors, and bash.
 
 ![lang: bash](https://img.shields.io/badge/lang-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 152 passing](https://img.shields.io/badge/tests-152%20passing-brightgreen?style=flat)](test/)
+[![tests: 158 passing](https://img.shields.io/badge/tests-158%20passing-brightgreen?style=flat)](test/)
 ![deps: jq + gum](https://img.shields.io/badge/deps-jq%20%2B%20gum-blue?style=flat)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)
 
@@ -90,7 +90,7 @@ FYI — just pushed the load testing scenarios to the note.
 
 ## Commands
 
-**10 commands**, each a standalone bash script in `.mise/tasks/`:
+**11 commands**, each a standalone bash script in `.mise/tasks/`:
 
 
 ### chat clear
@@ -183,6 +183,20 @@ chat send [--as <as>] [--chat <chat>] [-f, --force] <message>
 | `--as`        | Your identity (default: $CHAT_IDENTITY)       | —       |
 | `--chat`      | Chat name (default: $CHAT_CHANNEL or default) | —       |
 | `-f, --force` | Send even if there are unread messages        | —       |
+
+
+### chat sig
+
+Manage your message signature
+
+```
+chat sig [--as <as>] [--clear] [signature]
+```
+
+| Flag      | Description                             | Default |
+| --------- | --------------------------------------- | ------- |
+| `--as`    | Your identity (default: $CHAT_IDENTITY) | —       |
+| `--clear` | Remove your signature                   | —       |
 
 
 ### chat status
@@ -321,7 +335,7 @@ cd chat && mise trust && mise install
 mise run test
 ```
 
-152 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
+158 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ $HOME/.local/share/chat/
 │       ├── zeke            # "42" — last-read line number
 │       ├── brownie         # "38"
 │       └── junior          # "42"
+├── .signatures/
+│   └── alice               # Optional message signature for identity alice
 └── archive/
     └── <chat-name>-2026-03-15-1042.md
 ```

--- a/README.tsx
+++ b/README.tsx
@@ -322,6 +322,8 @@ chat status`}</CodeBlock>
 │       ├── zeke            # "42" — last-read line number
 │       ├── brownie         # "38"
 │       └── junior          # "42"
+├── .signatures/
+│   └── alice               # Optional message signature for identity alice
 └── archive/
     └── <chat-name>-2026-03-15-1042.md`}</CodeBlock>
     </Section>

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -262,6 +262,17 @@ load test_helper
   grep -q "forced" "$CHAT_FILE"
 }
 
+@test "task send: omitted --force ignores stale usage_force env" {
+  run chat send --as alice --chat test-chat "first"
+  [ "$status" -eq 0 ]
+  mark_read "alice"
+  send_message "bob" "unread"
+
+  usage_force=true run chat send --as alice --chat test-chat "blocked"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Aborted: you have 1 unread message(s) in test-chat."* ]]
+}
+
 @test "task send: new agent (cursor=0) bypasses guard" {
   # bob has never read — cursor is 0
   send_message "carol" "some message"
@@ -312,6 +323,62 @@ load test_helper
   run chat read test-chat --as alice
   [ "$status" -eq 0 ]
   [[ "$output" == *"hey alice"* ]]
+}
+
+# ============================================================================
+# sig task
+# ============================================================================
+
+@test "task sig: sets and shows signature" {
+  run chat sig --as alice "sent from pi"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Signature set for alice."* ]]
+
+  run chat sig --as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Signature for alice:"* ]]
+  [[ "$output" == *"sent from pi"* ]]
+}
+
+@test "task sig: send appends signature" {
+  run chat sig --as alice "sent from pi"
+  [ "$status" -eq 0 ]
+
+  run chat send --as alice --chat test-chat "hello"
+  [ "$status" -eq 0 ]
+  grep -q "hello" "$CHAT_FILE"
+  grep -q '^--$' "$CHAT_FILE"
+  grep -q "sent from pi" "$CHAT_FILE"
+}
+
+@test "task sig: clear removes signature" {
+  run chat sig --as alice "sent from pi"
+  [ "$status" -eq 0 ]
+
+  run chat sig --as alice --clear
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Signature cleared for alice."* ]]
+
+  run chat send --as alice --chat test-chat "hello"
+  [ "$status" -eq 0 ]
+  grep -q "hello" "$CHAT_FILE"
+  ! grep -q "sent from pi" "$CHAT_FILE"
+}
+
+@test "task sig: rejects clear with signature text" {
+  run chat sig --as alice --clear "sent from pi"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not both"* ]]
+}
+
+@test "task sig: omitted --clear ignores stale usage_clear env" {
+  usage_clear=true run chat sig --as alice "sent from pi"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Signature set for alice."* ]]
+
+  run chat sig --as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sent from pi"* ]]
 }
 
 # ============================================================================


### PR DESCRIPTION
Closes #28.

Adds a `chat sig` task for managing per-identity signatures, and appends them automatically on `chat send`.

## Interface

```
chat sig [--as <as>] [--clear] [signature]
```

| Invocation | Behaviour |
|---|---|
| `chat sig --as alice 'sent from pi'` | Set alice's signature |
| `chat sig --as alice` | Show alice's current signature |
| `chat sig --as alice --clear` | Remove alice's signature |

## How it works

- Signatures are stored globally in `$CHAT_DATA_DIR/.signatures/<identity>` — one file per identity, same convention as cursors
- On `chat send`, after the 10-line body check, the signature is appended with a `-- ` separator:

```
message body

--
sent from pi
```

- The line limit applies to the message body only, not the signature

## Files changed

- `.mise/tasks/sig` — new task
- `.mise/tasks/send` — append signature before `chat_append`

🤖 Generated with [Claude Code](https://claude.com/claude-code)