### PR TITLE
feat: cursor:undo — restore previous read position

### DIFF
--- a/.mise/tasks/clear
+++ b/.mise/tasks/clear
@@ -2,6 +2,9 @@
 #MISE description="Archive old messages and reset a chat"
 #USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--yes" help="Skip confirmation"
+#USAGE example "chat clear" header="Reset the default chat"
+#USAGE example "chat clear myproject" header="Reset a specific chat"
+#USAGE example "chat clear --yes" header="Skip the confirmation prompt"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"

--- a/.mise/tasks/cursor/clear
+++ b/.mise/tasks/cursor/clear
@@ -2,6 +2,8 @@
 #MISE description="Clear your cursor (mark everything as unread)"
 #USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
+#USAGE example "chat cursor clear --as alice" header="Mark all messages as unread for alice"
+#USAGE example "chat cursor clear ops --as alice" header="Mark a specific chat as unread"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"

--- a/.mise/tasks/cursor/clear
+++ b/.mise/tasks/cursor/clear
@@ -18,5 +18,5 @@ if [ ! -f "$cursor_file" ]; then
   exit 0
 fi
 
-rm -f "$cursor_file"
+rm -f "$cursor_file" "${cursor_file}.prev"
 echo "Cursor cleared for $CHAT_IDENTITY on $CHAT_NAME."

--- a/.mise/tasks/cursor/undo
+++ b/.mise/tasks/cursor/undo
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#MISE description="Undo the last cursor advance (restore previous read position)"
+#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
+#USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
+#USAGE example "chat cursor undo --as alice" header="Restore alice's cursor to before the last read"
+#USAGE example "chat cursor undo ops --as alice" header="Restore cursor on a specific chat"
+set -eo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/chat.sh"
+chat_resolve "${usage_chat:-}"
+chat_require_file
+chat_require_identity "${usage_as:-}"
+
+cursor_file="$CHAT_CURSOR_DIR/$CHAT_IDENTITY"
+prev_file="${cursor_file}.prev"
+
+if [ ! -f "$prev_file" ]; then
+  echo "Nothing to undo for $CHAT_IDENTITY on $CHAT_NAME."
+  exit 0
+fi
+
+mv "$prev_file" "$cursor_file"
+echo "Cursor restored for $CHAT_IDENTITY on $CHAT_NAME."

--- a/.mise/tasks/list
+++ b/.mise/tasks/list
@@ -4,6 +4,10 @@
 #USAGE flag "--all" help="Include empty channels (hidden by default)"
 #USAGE flag "--unread" help="Only list channels with unread messages (requires identity)"
 #USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY). When set, an Unread column is shown."
+#USAGE example "chat list" header="List all chats"
+#USAGE example "chat list --as alice" header="List chats with unread counts for alice"
+#USAGE example "chat list --unread --as alice" header="Show only chats with new messages"
+#USAGE example "chat list --json" header="Output as JSON"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"

--- a/.mise/tasks/merge
+++ b/.mise/tasks/merge
@@ -4,6 +4,9 @@
 #USAGE arg "<target>" help="Target channel to merge INTO"
 #USAGE flag "--dry-run" help="Show what would happen without writing"
 #USAGE flag "--no-tag" help="Don't annotate messages with source channel"
+#USAGE example "chat merge ops main" header="Merge ops into main (ops is consumed)"
+#USAGE example "chat merge ops main --dry-run" header="Preview the merge without writing"
+#USAGE example "chat merge ops main --no-tag" header="Merge without source channel annotations"
 # /// script
 # requires-python = ">=3.10"
 # ///

--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -10,6 +10,11 @@
 #USAGE flag "--before <before>" help="Show messages before this date (YYYY-MM-DD)"
 #USAGE flag "--json" help="Output as JSON array"
 #USAGE flag "--id" help="Include message IDs in JSON output"
+#USAGE example "chat read --as alice" header="Read new messages as alice"
+#USAGE example "chat read --all --last 10" header="Show the last 10 messages"
+#USAGE example "chat read --from bob" header="Filter messages from bob"
+#USAGE example "chat read --after 2025-01-01" header="Show messages after a date"
+#USAGE example "chat read --json --as alice" header="Output new messages as JSON"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"

--- a/.mise/tasks/remove
+++ b/.mise/tasks/remove
@@ -2,6 +2,8 @@
 #MISE description="Permanently remove a chat channel"
 #USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--yes" help="Skip confirmation"
+#USAGE example "chat remove myproject" header="Remove a chat channel"
+#USAGE example "chat remove myproject --yes" header="Remove without confirmation"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -4,6 +4,10 @@
 #USAGE flag "--chat <chat>" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "-f --force" help="Send even if there are unread messages"
 #USAGE arg "<message>" help="The message to send (or - for stdin)"
+#USAGE example "chat send --as alice 'hello everyone'" header="Send a message as alice"
+#USAGE example "chat send --chat ops --as alice 'deploying now'" header="Send to a specific chat"
+#USAGE example "echo 'status update' | chat send --as alice -" header="Send from stdin"
+#USAGE example "chat send --as alice --force 'urgent update'" header="Send even if you have unread messages"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -3,6 +3,10 @@
 #USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
 #USAGE flag "--as <as>" help="Your identity — shows unread count (default: $CHAT_IDENTITY)"
 #USAGE flag "--json" help="Output as JSON object"
+#USAGE example "chat status" header="Show default chat status"
+#USAGE example "chat status ops" header="Show a specific chat's status"
+#USAGE example "chat status --as alice" header="Show status with unread count for alice"
+#USAGE example "chat status --json" header="Output as JSON"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"

--- a/.mise/tasks/unread
+++ b/.mise/tasks/unread
@@ -3,6 +3,8 @@
 #USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)"
 #USAGE flag "--json" help="Output as JSON with per-channel breakdown"
 #USAGE flag "--max-parallel <max_parallel>" default="8" help="Max channels to check in parallel"
+#USAGE example "chat unread --as alice" header="Count all unread messages for alice"
+#USAGE example "chat unread --as alice --json" header="Per-channel breakdown as JSON"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -5,6 +5,11 @@
 #USAGE flag "--timeout <seconds>" help="Max seconds to wait (0 = forever)" default="120"
 #USAGE flag "--forever" help="Wait indefinitely (shorthand for --timeout 0)"
 #USAGE flag "--batch <batch>" help="Wait for N messages from others before waking (default: 1)" default="1"
+#USAGE example "chat wait --as alice" header="Wait for any new message"
+#USAGE example "chat wait ops --as alice" header="Wait for a message in a specific chat"
+#USAGE example "chat wait --as alice --timeout 60" header="Wait with a 60-second timeout"
+#USAGE example "chat wait --as alice --forever" header="Wait indefinitely"
+#USAGE example "chat wait --as alice --batch 3" header="Wait for 3 messages from others"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ These exist because agents are fast and chatty. Without guardrails, you get eigh
 ## Development
 
 ```bash
-git clone https://github.com/KnickKnackLabs/chat.git
+git clone https://github.com/olavostauros/chat.git
 cd chat && mise trust && mise install
 mise run test
 ```

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ These exist because agents are fast and chatty. Without guardrails, you get eigh
 ## Development
 
 ```bash
-git clone https://github.com/olavostauros/chat.git
+git clone https://github.com/KnickKnackLabs/chat.git
 cd chat && mise trust && mise install
 mise run test
 ```

--- a/lib/chat.sh
+++ b/lib/chat.sh
@@ -87,9 +87,11 @@ chat_set_cursor() {
     echo "Error: agent name required for chat_set_cursor" >&2
     return 1
   fi
+  local cursor_file="$CHAT_CURSOR_DIR/$agent"
   local count
   count=$(chat_line_count)
-  printf '%s' "$count" > "$CHAT_CURSOR_DIR/$agent"
+  [ -f "$cursor_file" ] && cp "$cursor_file" "${cursor_file}.prev"
+  printf '%s' "$count" > "$cursor_file"
 }
 
 # Format a timestamp

--- a/test/chat_lib.bats
+++ b/test/chat_lib.bats
@@ -162,6 +162,25 @@ load test_helper
   [ "$status" -ne 0 ]
 }
 
+@test "cursor: set saves .prev when cursor already exists" {
+  send_message "bob" "first"
+  chat_set_cursor "alice"
+  local first_pos
+  first_pos=$(chat_get_cursor "alice")
+
+  send_message "bob" "second"
+  chat_set_cursor "alice"
+
+  local prev_file="$CHAT_CURSOR_DIR/alice.prev"
+  [ -f "$prev_file" ]
+  [ "$(cat "$prev_file")" = "$first_pos" ]
+}
+
+@test "cursor: set does not create .prev on first advance" {
+  chat_set_cursor "alice"
+  [ ! -f "$CHAT_CURSOR_DIR/alice.prev" ]
+}
+
 # ============================================================================
 # chat_append
 # ============================================================================

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -710,6 +710,102 @@ assert 'unread' not in data, f'unread should not be present without --as, got: {
 }
 
 # ============================================================================
+# cursor:undo task
+# ============================================================================
+
+@test "task cursor:undo: restores cursor to pre-read position" {
+  send_message "bob" "msg1"
+  mark_read "alice"
+  local cursor_before
+  cursor_before=$(chat_get_cursor "alice")
+
+  send_message "bob" "msg2"
+  run chat read test-chat --as alice
+  [ "$status" -eq 0 ]
+
+  run chat cursor:undo test-chat --as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Cursor restored"* ]]
+
+  local cursor_after
+  cursor_after=$(chat_get_cursor "alice")
+  [ "$cursor_after" = "$cursor_before" ]
+}
+
+@test "task cursor:undo: second read after undo shows same messages" {
+  mark_read "alice"
+  send_message "bob" "hello again"
+
+  run chat read test-chat --as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello again"* ]]
+
+  run chat cursor:undo test-chat --as alice
+  [ "$status" -eq 0 ]
+
+  run chat read test-chat --as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello again"* ]]
+}
+
+@test "task cursor:undo: no-op when no prior read" {
+  run chat cursor:undo test-chat --as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Nothing to undo"* ]]
+}
+
+@test "task cursor:undo: no-op after read --peek" {
+  mark_read "alice"
+  send_message "bob" "peeked"
+
+  run chat read test-chat --as alice --peek
+  [ "$status" -eq 0 ]
+
+  run chat cursor:undo test-chat --as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Nothing to undo"* ]]
+}
+
+@test "task cursor:undo: second undo is a no-op (one level only)" {
+  send_message "bob" "msg"
+  mark_read "alice"
+  send_message "bob" "msg2"
+
+  run chat read test-chat --as alice
+  [ "$status" -eq 0 ]
+
+  run chat cursor:undo test-chat --as alice
+  [ "$status" -eq 0 ]
+
+  run chat cursor:undo test-chat --as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Nothing to undo"* ]]
+}
+
+@test "task cursor:undo: no-op after cursor:clear" {
+  send_message "bob" "msg"
+  mark_read "alice"
+  send_message "bob" "msg2"
+
+  run chat read test-chat --as alice
+  [ "$status" -eq 0 ]
+
+  run chat cursor:clear test-chat --as alice
+  [ "$status" -eq 0 ]
+
+  run chat cursor:undo test-chat --as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Nothing to undo"* ]]
+}
+
+@test "task cursor:undo: requires identity" {
+  unset CHAT_IDENTITY
+  run chat cursor:undo test-chat
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"identity required"* ]]
+}
+
+# ============================================================================
 # non-existent channel — read-only commands should fail, send should create
 # ============================================================================
 
@@ -744,6 +840,12 @@ assert 'unread' not in data, f'unread should not be present without --as, got: {
 
 @test "task cursor:clear: fails on non-existent channel" {
   run chat cursor:clear no-such-channel --as alice
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "task cursor:undo: fails on non-existent channel" {
+  run chat cursor:undo no-such-channel --as alice
   [ "$status" -ne 0 ]
   [[ "$output" == *"does not exist"* ]]
 }


### PR DESCRIPTION
Closes #18.

## Summary

- `lib/chat.sh` — `chat_set_cursor` saves the current cursor to `$agent.prev` before overwriting. All three call sites in `read` get this automatically; `--peek` never calls `chat_set_cursor` so peeking produces no `.prev`
- `.mise/tasks/cursor/undo` — new task, mirrors `cursor:clear`; `mv`s `.prev` back into the cursor file (consuming it so double-undo correctly finds nothing)
- `.mise/tasks/cursor/clear` — also removes `.prev` so undo after clear finds nothing
- 10 new tests (2 lib-level, 8 task-level) covering the happy path, no-op cases, peek, double-undo, and clear-then-undo

## Test plan

- [x] `mise run test` → 159/159 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)