### PR TITLE
readme: parse usage attributes in any order

### DIFF
--- a/.mise/tasks/export
+++ b/.mise/tasks/export
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #MISE description="Export a channel's message history to blob storage"
-#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)" default=""
-#USAGE flag "--format <format>" help="Export format: md or json" default="md"
-#USAGE flag "--after <after>" help="Export messages after this date (YYYY-MM-DD)" default=""
-#USAGE flag "--before <before>" help="Export messages before this date (YYYY-MM-DD)" default=""
-#USAGE flag "--key <key>" help="Override blob key (default: chat/<channel>/<YYYY-MM-DD-HHMMSS>.<ext>)" default=""
-#USAGE flag "--stdout" help="Print to stdout instead of uploading" default=#false
+#USAGE arg "[chat]" default="" help="Chat name (default: $CHAT_CHANNEL or default)"
+#USAGE flag "--format <format>" default="md" help="Export format: md or json"
+#USAGE flag "--after <after>" default="" help="Export messages after this date (YYYY-MM-DD)"
+#USAGE flag "--before <before>" default="" help="Export messages before this date (YYYY-MM-DD)"
+#USAGE flag "--key <key>" default="" help="Override blob key (default: chat/<channel>/<YYYY-MM-DD-HHMMSS>.<ext>)"
+#USAGE flag "--stdout" default=#false help="Print to stdout instead of uploading"
 #USAGE example "chat export mise-research" header="Export mise-research to blob storage"
 #USAGE example "chat export mise-research --format json" header="Export as JSON"
 #USAGE example "chat export mise-research --after 2026-03-01" header="Partial export from a date"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agents on the same machine exchange short messages through a shared channel.
 No server. No daemon. Just files, cursors, and bash.
 
 ![lang: bash](https://img.shields.io/badge/lang-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 164 passing](https://img.shields.io/badge/tests-164%20passing-brightgreen?style=flat)](test/)
+[![tests: 165 passing](https://img.shields.io/badge/tests-165%20passing-brightgreen?style=flat)](test/)
 ![deps: jq + gum + blobs](https://img.shields.io/badge/deps-jq%20%2B%20gum%20%2B%20blobs-blue?style=flat)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)
 
@@ -244,13 +244,14 @@ chat test
 Count total unread messages across all channels
 
 ```
-chat unread [--as <as>] [--json]
+chat unread [--as <as>] [--json] [--max-parallel <max_parallel>]
 ```
 
-| Flag     | Description                               | Default |
-| -------- | ----------------------------------------- | ------- |
-| `--as`   | Your identity (default: $CHAT_IDENTITY)   | —       |
-| `--json` | Output as JSON with per-channel breakdown | —       |
+| Flag             | Description                               | Default |
+| ---------------- | ----------------------------------------- | ------- |
+| `--as`           | Your identity (default: $CHAT_IDENTITY)   | —       |
+| `--json`         | Output as JSON with per-channel breakdown | —       |
+| `--max-parallel` | Max channels to check in parallel         | `8`     |
 
 
 ### chat wait
@@ -354,7 +355,7 @@ cd chat && mise trust && mise install
 mise run test
 ```
 
-164 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
+165 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
 
 <br />
 

--- a/README.tsx
+++ b/README.tsx
@@ -11,6 +11,7 @@ import {
   List, Item,
   Raw, HtmlLink, Sub, HtmlTable, HtmlTr, HtmlTd,
 } from "readme/src/components";
+import { parseMiseTasks, type MiseCommand } from "./readme/mise";
 
 // ── Dynamic data ─────────────────────────────────────────────
 
@@ -19,56 +20,7 @@ const TASK_DIR = join(REPO_DIR, ".mise/tasks");
 const LIB_FILE = join(REPO_DIR, "lib/chat.sh");
 
 // Extract commands from task files by parsing #MISE and #USAGE headers
-interface Command {
-  name: string;
-  description: string;
-  flags: { name: string; shortFlag?: string; valueName?: string; help: string; required?: boolean; default?: string; isBoolean: boolean }[];
-  args: { name: string; help: string; optional: boolean }[];
-  hidden: boolean;
-}
-
-function parseTask(filename: string): Command {
-  const src = readFileSync(join(TASK_DIR, filename), "utf-8");
-  const lines = src.split("\n");
-
-  const desc = lines.find(l => l.startsWith("#MISE description="))
-    ?.match(/#MISE description="(.+)"/)?.[1] ?? "";
-
-  const hidden = lines.some(l => l.includes("#MISE hide=true"));
-
-  const flags: Command["flags"] = [];
-  const args: Command["args"] = [];
-
-  for (const line of lines) {
-    const flagMatch = line.match(/#USAGE flag "(-[\w-]+ )?--(\w[\w-]*)(?:\s+<(\w+)>)?" help="([^"]+)"(.*)/);
-    if (flagMatch) {
-      const shortFlag = flagMatch[1]?.trim(); // e.g. "-f"
-      const name = flagMatch[2].replace(/_/g, "-");
-      const valueName = flagMatch[3]; // e.g. "seconds" — undefined for boolean flags
-      const help = flagMatch[4];
-      const rest = flagMatch[5] || "";
-      const required = rest.includes("required=#true");
-      const defMatch = rest.match(/default="([^"]+)"/);
-      flags.push({ name: `--${name}`, shortFlag, valueName, help, required: required || undefined, default: defMatch?.[1], isBoolean: !valueName });
-    }
-
-    const argMatch = line.match(/#USAGE arg "([<\[])(\w+)([>\]])" help="([^"]+)"/);
-    if (argMatch) {
-      args.push({ name: argMatch[2], help: argMatch[4], optional: argMatch[1] === "[" });
-    }
-  }
-
-  return { name: filename, description: desc, flags, args, hidden };
-}
-
-// Parse all tasks
-const taskFiles = readdirSync(TASK_DIR, { withFileTypes: true })
-  .filter(entry => entry.isFile() && !entry.name.startsWith(".") && !entry.name.startsWith("_"))
-  .map(entry => entry.name);
-const commands = taskFiles
-  .map(parseTask)
-  .filter(c => !c.hidden)
-  .sort((a, b) => a.name.localeCompare(b.name));
+const commands = parseMiseTasks(TASK_DIR);
 
 // Count tests
 const testDir = join(REPO_DIR, "test");
@@ -118,7 +70,7 @@ const cursorDiagram = [
 ].join("\n");
 
 // Build command usage string
-function cmdUsage(cmd: Command): string {
+function cmdUsage(cmd: MiseCommand): string {
   const parts = [`chat ${cmd.name}`];
   for (const f of cmd.flags) {
     const flagName = f.shortFlag ? `${f.shortFlag}, ${f.name}` : f.name;

--- a/readme/mise.ts
+++ b/readme/mise.ts
@@ -1,0 +1,94 @@
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+export interface MiseCommand {
+  name: string;
+  description: string;
+  flags: {
+    name: string;
+    shortFlag?: string;
+    valueName?: string;
+    help: string;
+    required?: boolean;
+    default?: string;
+    isBoolean: boolean;
+  }[];
+  args: { name: string; help: string; optional: boolean }[];
+  hidden: boolean;
+}
+
+type UsageAttrs = Record<string, string | boolean>;
+
+function parseUsageAttrs(rest: string): UsageAttrs {
+  const attrs: UsageAttrs = {};
+  const attrRe = /(\w[\w-]*)=(?:"([^"]*)"|#(true|false)|([^\s]+))/g;
+  for (const match of rest.matchAll(attrRe)) {
+    const [, key, quoted, bool, bare] = match;
+    if (bool) {
+      attrs[key] = bool === "true";
+    } else {
+      attrs[key] = quoted ?? bare ?? "";
+    }
+  }
+  return attrs;
+}
+
+function stringAttr(attrs: UsageAttrs, key: string): string | undefined {
+  const value = attrs[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function parseMiseTask(taskDir: string, filename: string): MiseCommand {
+  const src = readFileSync(join(taskDir, filename), "utf-8");
+  const lines = src.split("\n");
+
+  const desc = lines.find(l => l.startsWith("#MISE description="))
+    ?.match(/#MISE description="(.+)"/)?.[1] ?? "";
+
+  const hidden = lines.some(l => l.includes("#MISE hide=true"));
+
+  const flags: MiseCommand["flags"] = [];
+  const args: MiseCommand["args"] = [];
+
+  for (const line of lines) {
+    const flagMatch = line.match(/#USAGE flag "(-[\w-]+ )?--(\w[\w-]*)(?:\s+<(\w+)>)?"(.*)$/);
+    if (flagMatch) {
+      const shortFlag = flagMatch[1]?.trim();
+      const name = flagMatch[2].replace(/_/g, "-");
+      const valueName = flagMatch[3];
+      const attrs = parseUsageAttrs(flagMatch[4] || "");
+      const help = stringAttr(attrs, "help") ?? "";
+      const required = attrs.required === true;
+      const defaultValue = stringAttr(attrs, "default");
+      flags.push({
+        name: `--${name}`,
+        shortFlag,
+        valueName,
+        help,
+        required: required || undefined,
+        default: defaultValue,
+        isBoolean: !valueName,
+      });
+    }
+
+    const argMatch = line.match(/#USAGE arg "([<\[])(\w+)([>\]])"(.*)$/);
+    if (argMatch) {
+      const attrs = parseUsageAttrs(argMatch[4] || "");
+      args.push({
+        name: argMatch[2],
+        help: stringAttr(attrs, "help") ?? "",
+        optional: argMatch[1] === "[",
+      });
+    }
+  }
+
+  return { name: filename, description: desc, flags, args, hidden };
+}
+
+export function parseMiseTasks(taskDir: string): MiseCommand[] {
+  return readdirSync(taskDir, { withFileTypes: true })
+    .filter(entry => entry.isFile() && !entry.name.startsWith(".") && !entry.name.startsWith("_"))
+    .map(entry => parseMiseTask(taskDir, entry.name))
+    .filter(command => !command.hidden)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -421,6 +421,12 @@ assert data[0]['body'] == 'hello'
   [[ "$output" == *"--format must be md or json"* ]]
 }
 
+@test "task export: README documents flags when default precedes help" {
+  grep -q 'chat export \[--format <format>\].*\[chat\]' "$CHAT_REPO_ROOT/README.md"
+  grep -q '| `--format` | Export format: md or json.*| `md`' "$CHAT_REPO_ROOT/README.md"
+  grep -q '| `--stdout` | Print to stdout instead of uploading' "$CHAT_REPO_ROOT/README.md"
+}
+
 @test "task export: upload requires blob env" {
   send_message "alice" "hello"
   run chat export test-chat


### PR DESCRIPTION
## Summary

Fixes the README task parser so `#USAGE` attributes can appear in any order instead of requiring `help="..."` before `default=...`.

This lets task headers use the preferred `default`-before-`help` shape without dropping flags from generated README output.

## Changes

- Extract mise-task README parsing into `readme/mise.ts` as a local test-drive for reusable mise README helpers.
- Parse `#USAGE` attrs order-independently.
- Move `chat export` USAGE lines to `default=... help=...`.
- Regenerate `README.md`.
- Add regression coverage that the export flags still appear in README when defaults precede help.

## Validation

- `readme build`
- `mise run test test/tasks.bats --filter 'README documents|task export:'` (7/7)
- `mise run test` (165/165)
- configured codebase lints individually: `mise-settings`, `gum-table`, `bats-test-helper`, `bats-test-task`, `mcr-scope`, `or-true`, `shellcheck`
- `git diff --check`

Note: I accidentally tried `bun --check README.tsx` first; that is not a repo validation path here because `readme` owns its runtime and `chat` does not declare Bun. I reran validation through `readme build`.
