### PR TITLE
read: clear diagnostic when no channel can be inferred (#38)

### DIFF
--- a/lib/chat.sh
+++ b/lib/chat.sh
@@ -28,14 +28,20 @@ chat_require_identity() {
 # Resolve which chat we're targeting.
 # Priority: explicit name > $CHAT_CHANNEL env var > "default"
 # Usage: chat_resolve [name]
-# Sets CHAT_NAME, CHAT_FILE, CHAT_CURSOR_DIR
+# Sets CHAT_NAME, CHAT_FILE, CHAT_CURSOR_DIR, CHAT_NAME_SOURCE
+# CHAT_NAME_SOURCE records where the name came from (explicit|env|default) so
+# read-only commands can tell "you named a channel that's missing" apart from
+# "no channel was specified or inferred".
 chat_resolve() {
   if [ -n "${1:-}" ]; then
     CHAT_NAME="$1"
+    CHAT_NAME_SOURCE="explicit"
   elif [ -n "${CHAT_CHANNEL:-}" ]; then
     CHAT_NAME="$CHAT_CHANNEL"
+    CHAT_NAME_SOURCE="env"
   else
     CHAT_NAME="default"
+    CHAT_NAME_SOURCE="default"
   fi
   CHAT_FILE="$CHAT_DATA_DIR/${CHAT_NAME}.md"
   CHAT_CURSOR_DIR="$CHAT_DATA_DIR/.cursors/${CHAT_NAME}"
@@ -44,8 +50,14 @@ chat_resolve() {
 # Require that the chat file already exists — for read-only commands
 chat_require_file() {
   if [ ! -f "$CHAT_FILE" ]; then
-    echo "Error: chat '${CHAT_NAME}' does not exist." >&2
-    echo "Create it by sending a message: chat send --chat ${CHAT_NAME} --as <name> \"hello\"" >&2
+    # No channel was named or inferred — don't point at the phantom default.
+    if [ "${CHAT_NAME_SOURCE:-explicit}" = "default" ]; then
+      echo "Error: no chat channel specified and no default channel could be inferred." >&2
+      echo "Pass a channel name or set \$CHAT_CHANNEL (e.g. chat read den --as ikma)." >&2
+    else
+      echo "Error: chat '${CHAT_NAME}' does not exist." >&2
+      echo "Create it by sending a message: chat send --chat ${CHAT_NAME} --as <name> \"hello\"" >&2
+    fi
     return 1
   fi
 }

--- a/test/chat_lib.bats
+++ b/test/chat_lib.bats
@@ -43,6 +43,47 @@ load test_helper
   [ "$CHAT_NAME" = "default" ]
 }
 
+@test "resolve: explicit name sets CHAT_NAME_SOURCE=explicit" {
+  chat_resolve "my-chat"
+  [ "$CHAT_NAME_SOURCE" = "explicit" ]
+}
+
+@test "resolve: CHAT_CHANNEL sets CHAT_NAME_SOURCE=env" {
+  CHAT_CHANNEL="from-env" chat_resolve ""
+  [ "$CHAT_NAME_SOURCE" = "env" ]
+}
+
+@test "resolve: empty name sets CHAT_NAME_SOURCE=default" {
+  chat_resolve ""
+  [ "$CHAT_NAME_SOURCE" = "default" ]
+}
+
+# ============================================================================
+# chat_require_file
+# ============================================================================
+
+@test "require_file: succeeds when the chat file exists" {
+  chat_resolve "test-chat"   # created by setup() via chat_init
+  run chat_require_file
+  [ "$status" -eq 0 ]
+}
+
+@test "require_file: named-but-missing channel points at 'create by sending'" {
+  chat_resolve "ghost"
+  run chat_require_file
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"chat 'ghost' does not exist"* ]]
+  [[ "$output" == *"Create it by sending"* ]]
+}
+
+@test "require_file: no inferred channel gives a no-channel diagnostic" {
+  chat_resolve ""   # falls back to default, which does not exist
+  run chat_require_file
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no chat channel specified"* ]]
+  [[ "$output" != *"Create it by sending"* ]]
+}
+
 # ============================================================================
 # chat_resolve_identity / chat_require_identity
 # ============================================================================

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -37,6 +37,13 @@ load test_helper
   [[ "$output" == *"No new messages"* ]]
 }
 
+@test "task read: no channel inferred fails with a clear diagnostic" {
+  # No positional channel and no $CHAT_CHANNEL → default is inferred but absent.
+  run chat read --as alice
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no chat channel"* ]]
+}
+
 @test "task read: --peek does not advance cursor" {
   mark_read "alice"
   send_message "bob" "peeked"


### PR DESCRIPTION
Closes #38.

## Problem

`chat read --as <id>` with no positional channel and no `$CHAT_CHANNEL` set
silently fell back to a phantom `default` channel, then failed with a
misleading error telling the user to *create* a channel they never asked for:

```
Error: chat 'default' does not exist.
Create it by sending a message: chat send --chat default --as <name> "hello"
```

(The reporter saw the literal `chat` rather than `default` because their
installed shim leaks the command name into the positional — a separate shiv
shim quirk; the chat-side defect and fix are the same regardless.)

## Root cause

`chat_resolve` (`lib/chat.sh`) defaults `CHAT_NAME` to `"default"` whenever
neither an explicit name nor `$CHAT_CHANNEL` is provided. For read-only
commands, `chat_require_file` then can't tell "you named a channel that's
missing" apart from "no channel was specified or inferred", so it emits the
same "create it by sending" hint in both cases.

## Fix

- `chat_resolve` now records where the name came from in a new global
  `CHAT_NAME_SOURCE` (`explicit` | `env` | `default`). Purely additive —
  `CHAT_NAME`/`CHAT_FILE`/`CHAT_CURSOR_DIR` are unchanged.
- `chat_require_file` branches on it. When nothing was inferred (`default`):

  ```
  Error: no chat channel specified and no default channel could be inferred.
  Pass a channel name or set $CHAT_CHANNEL (e.g. chat read den --as ikma).
  ```

  When a channel *was* named (explicit/env) but is missing, the existing
  "create it by sending" message is preserved.

This fixes every read-only caller at once (`read`, `clear`, `cursor/clear`,
`cursor/undo`, `export`, `remove`, `status`, `wait`) since they all go through
`chat_resolve` → `chat_require_file`. The `send` write path (which auto-creates
`default`) never calls `chat_require_file` and is untouched. Reading an existing
`default` channel still works.

## Tests

- `test/chat_lib.bats`: provenance is set correctly for explicit/env/default,
  and `chat_require_file` emits the right message in each case (named-but-missing
  vs no-channel-inferred) plus a success sanity check.
- `test/tasks.bats`: `chat read --as alice` with no channel inferred fails with
  the new diagnostic.

## Verification

Lib-level suite green locally (`bats test/chat_lib.bats`, 66/66), and the `read`
task script run directly with no inferred channel emits the new diagnostic and
exits 1. The task-level bats suite runs in CI (it drives tasks through `mise run`).

