### PR TITLE
fix(send): replace positional message with --msg flag (#23)

### DIFF
--- a/.mise/tasks/readme
+++ b/.mise/tasks/readme
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Regenerate README.md from README.tsx"
 #MISE hide=true
-#USAGE flag "--check" help="Check if README.md is up to date (exit 1 if stale)"
+#USAGE flag "--check" help="Check if README.md is up to date (exit 1 if stale)" default=#false
 set -euo pipefail
 
 cd "$MISE_CONFIG_ROOT"

--- a/.mise/tasks/readme
+++ b/.mise/tasks/readme
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 #MISE description="Regenerate README.md from README.tsx"
 #MISE hide=true
+#USAGE flag "--check" help="Check if README.md is up to date (exit 1 if stale)"
 set -euo pipefail
 
 cd "$MISE_CONFIG_ROOT"
-readme build
+export CALLER_PWD="$MISE_CONFIG_ROOT"
+
+args=()
+[ "${usage_check:-false}" = "true" ] && args+=(--check)
+
+readme build "${args[@]}"

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -3,11 +3,11 @@
 #USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)" default=""
 #USAGE flag "--chat <chat>" help="Chat name (default: $CHAT_CHANNEL or default)" default=""
 #USAGE flag "-f --force" help="Send even if there are unread messages" default=#false
-#USAGE arg "<message>" help="The message to send (or - for stdin)"
-#USAGE example "chat send --as alice 'hello everyone'" header="Send a message as alice"
-#USAGE example "chat send --chat ops --as alice 'deploying now'" header="Send to a specific chat"
-#USAGE example "echo 'status update' | chat send --as alice -" header="Send from stdin"
-#USAGE example "chat send --as alice --force 'urgent update'" header="Send even if you have unread messages"
+#USAGE flag "--msg <msg>" help="The message to send (or pipe input)"
+#USAGE example "chat send --as alice --msg 'hello everyone'" header="Send a message as alice"
+#USAGE example "chat send --chat ops --as alice --msg 'deploying now'" header="Send to a specific chat"
+#USAGE example "echo 'status update' | chat send --as alice" header="Send from stdin"
+#USAGE example "chat send --as alice --force --msg 'urgent update'" header="Send even if you have unread messages"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"
@@ -18,11 +18,13 @@ chat_init
 chat_require_identity "${usage_as:-}"
 from="$CHAT_IDENTITY"
 
-message="${usage_message}"
-
-# Read from stdin if message is "-"
-if [ "$message" = "-" ]; then
+if [ -n "${usage_msg:-}" ]; then
+  message="$usage_msg"
+elif ! [ -t 0 ]; then
   message=$(cat)
+else
+  echo "Error: no message provided. Use --msg or pipe input." >&2
+  exit 1
 fi
 
 if [ -z "$message" ]; then

--- a/.mise/tasks/send
+++ b/.mise/tasks/send
@@ -3,7 +3,7 @@
 #USAGE flag "--as <as>" help="Your identity (default: $CHAT_IDENTITY)" default=""
 #USAGE flag "--chat <chat>" help="Chat name (default: $CHAT_CHANNEL or default)" default=""
 #USAGE flag "-f --force" help="Send even if there are unread messages" default=#false
-#USAGE flag "--msg <msg>" help="The message to send (or pipe input)"
+#USAGE flag "--msg <msg>" help="The message to send (or pipe input)" default=""
 #USAGE example "chat send --as alice --msg 'hello everyone'" header="Send a message as alice"
 #USAGE example "chat send --chat ops --as alice --msg 'deploying now'" header="Send to a specific chat"
 #USAGE example "echo 'status update' | chat send --as alice" header="Send from stdin"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agents on the same machine exchange short messages through a shared channel.
 No server. No daemon. Just files, cursors, and bash.
 
 ![lang: bash](https://img.shields.io/badge/lang-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 188 passing](https://img.shields.io/badge/tests-188%20passing-brightgreen?style=flat)](test/)
+[![tests: 189 passing](https://img.shields.io/badge/tests-189%20passing-brightgreen?style=flat)](test/)
 ![deps: jq + gum + blobs](https://img.shields.io/badge/deps-jq%20%2B%20gum%20%2B%20blobs-blue?style=flat)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)
 
@@ -356,7 +356,7 @@ cd chat && mise trust && mise install
 mise run test
 ```
 
-188 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
+189 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agents on the same machine exchange short messages through a shared channel.
 No server. No daemon. Just files, cursors, and bash.
 
 ![lang: bash](https://img.shields.io/badge/lang-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 180 passing](https://img.shields.io/badge/tests-180%20passing-brightgreen?style=flat)](test/)
+[![tests: 188 passing](https://img.shields.io/badge/tests-188%20passing-brightgreen?style=flat)](test/)
 ![deps: jq + gum + blobs](https://img.shields.io/badge/deps-jq%20%2B%20gum%20%2B%20blobs-blue?style=flat)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)
 
@@ -36,7 +36,7 @@ shiv install chat
 export CHAT_IDENTITY="brownie"
 
 # Send a message
-chat send "Hey everyone, good morning!"
+chat send --msg "Hey everyone, good morning!"
 
 # Read new messages
 chat read
@@ -192,7 +192,7 @@ chat remove [--yes] [chat]
 Send a message to a chat
 
 ```
-chat send [--as <as>] [--chat <chat>] [-f, --force] <message>
+chat send [--as <as>] [--chat <chat>] [-f, --force] [--msg <msg>]
 ```
 
 | Flag          | Description                                   | Default |
@@ -200,6 +200,7 @@ chat send [--as <as>] [--chat <chat>] [-f, --force] <message>
 | `--as`        | Your identity (default: $CHAT_IDENTITY)       | —       |
 | `--chat`      | Chat name (default: $CHAT_CHANNEL or default) | —       |
 | `-f, --force` | Send even if there are unread messages        | —       |
+| `--msg`       | The message to send (or pipe input)           | —       |
 
 
 ### chat sig
@@ -355,7 +356,7 @@ cd chat && mise trust && mise install
 mise run test
 ```
 
-180 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
+188 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
 
 <br />
 

--- a/README.tsx
+++ b/README.tsx
@@ -126,7 +126,7 @@ shiv install chat
 export CHAT_IDENTITY="brownie"
 
 # Send a message
-chat send "Hey everyone, good morning!"
+chat send --msg "Hey everyone, good morning!"
 
 # Read new messages
 chat read

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -170,25 +170,25 @@ load test_helper
 # ============================================================================
 
 @test "task send: appends message" {
-  run chat send --as alice --chat test-chat "hello world"
+  run chat send --as alice --chat test-chat --msg "hello world"
   [ "$status" -eq 0 ]
   grep -q "hello world" "$CHAT_FILE"
 }
 
 @test "task send: message has sender header" {
-  run chat send --as alice --chat test-chat "test"
+  run chat send --as alice --chat test-chat --msg "test"
   [ "$status" -eq 0 ]
   grep -q "^### alice" "$CHAT_FILE"
 }
 
 @test "task send: confirms with output" {
-  run chat send --as alice --chat test-chat "hi"
+  run chat send --as alice --chat test-chat --msg "hi"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sent to test-chat"* ]]
 }
 
 @test "task send: CHAT_IDENTITY env var used when --as omitted" {
-  CHAT_IDENTITY="alice" run chat send --chat test-chat "env identity send"
+  CHAT_IDENTITY="alice" run chat send --chat test-chat --msg "env identity send"
   [ "$status" -eq 0 ]
   grep -q "### alice" "$CHAT_FILE"
   grep -q "env identity send" "$CHAT_FILE"
@@ -196,13 +196,13 @@ load test_helper
 
 @test "task send: fails without identity" {
   unset CHAT_IDENTITY
-  run chat send --chat test-chat "no identity"
+  run chat send --chat test-chat --msg "no identity"
   [ "$status" -ne 0 ]
   [[ "$output" == *"identity required"* ]]
 }
 
 @test "task send: rejects empty message" {
-  run chat send --as alice --chat test-chat ""
+  run chat send --as alice --chat test-chat --msg ""
   [ "$status" -ne 0 ]
   [[ "$output" == *"empty"* ]]
 }
@@ -210,7 +210,7 @@ load test_helper
 @test "task send: rejects message over 10 lines" {
   local long_msg
   long_msg=$(printf 'line %s\n' $(seq 1 11))
-  run chat send --as alice --chat test-chat "$long_msg"
+  run chat send --as alice --chat test-chat --msg "$long_msg"
   [ "$status" -ne 0 ]
   [[ "$output" == *"too long"* ]]
 }
@@ -218,13 +218,13 @@ load test_helper
 @test "task send: allows message at exactly 10 lines" {
   local msg
   msg=$(printf 'line %s\n' $(seq 1 10))
-  run chat send --as alice --chat test-chat "$msg"
+  run chat send --as alice --chat test-chat --msg "$msg"
   [ "$status" -eq 0 ]
 }
 
 @test "task send: guard blocks send when unread messages exist" {
   # alice sends first message (cursor stays 0 — new agent, guard skips)
-  run chat send --as alice --chat test-chat "first"
+  run chat send --as alice --chat test-chat --msg "first"
   [ "$status" -eq 0 ]
 
   # alice reads to set cursor > 0
@@ -234,7 +234,7 @@ load test_helper
   send_message "bob" "unread msg"
 
   # alice tries to send — guard should block and show the unread message inline
-  run chat send --as alice --chat test-chat "blocked"
+  run chat send --as alice --chat test-chat --msg "blocked"
   [ "$status" -ne 0 ]
   [[ "$output" == *"Aborted: you have 1 unread message(s) in test-chat."* ]]
   [[ "$output" == *"unread msg"* ]]
@@ -250,7 +250,7 @@ load test_helper
   send_message "alice" "own two"
   send_message "alice" "own three"
 
-  run chat send --as alice --chat test-chat "blocked"
+  run chat send --as alice --chat test-chat --msg "blocked"
   [ "$status" -ne 0 ]
   [[ "$output" == *"blocking msg"* ]]
   [[ "$output" != *"own one"* ]]
@@ -259,23 +259,23 @@ load test_helper
 }
 
 @test "task send: --force bypasses unread guard" {
-  run chat send --as alice --chat test-chat "first"
+  run chat send --as alice --chat test-chat --msg "first"
   [ "$status" -eq 0 ]
   mark_read "alice"
   send_message "bob" "unread"
 
-  run chat send --as alice --chat test-chat "forced" --force
+  run chat send --as alice --chat test-chat --msg "forced" --force
   [ "$status" -eq 0 ]
   grep -q "forced" "$CHAT_FILE"
 }
 
 @test "task send: omitted --force ignores stale usage_force env" {
-  run chat send --as alice --chat test-chat "first"
+  run chat send --as alice --chat test-chat --msg "first"
   [ "$status" -eq 0 ]
   mark_read "alice"
   send_message "bob" "unread"
 
-  usage_force=true run chat send --as alice --chat test-chat "blocked"
+  usage_force=true run chat send --as alice --chat test-chat --msg "blocked"
   [ "$status" -ne 0 ]
   [[ "$output" == *"Aborted: you have 1 unread message(s) in test-chat."* ]]
 }
@@ -284,17 +284,17 @@ load test_helper
   # bob has never read — cursor is 0
   send_message "carol" "some message"
   # bob should be able to send despite carol's unread message
-  run chat send --as bob --chat test-chat "hi from bob"
+  run chat send --as bob --chat test-chat --msg "hi from bob"
   [ "$status" -eq 0 ]
 }
 
 @test "task send: new agent can send multiple times without reading (cursor=0)" {
   # alice has never read — cursor stays at 0, guard is skipped
-  run chat send --as alice --chat test-chat "first msg"
+  run chat send --as alice --chat test-chat --msg "first msg"
   [ "$status" -eq 0 ]
 
   # alice sends again — still cursor=0, guard still skipped
-  run chat send --as alice --chat test-chat "second msg"
+  run chat send --as alice --chat test-chat --msg "second msg"
   [ "$status" -eq 0 ]
   grep -q "second msg" "$CHAT_FILE"
 }
@@ -305,11 +305,11 @@ load test_helper
   mark_read "alice"
 
   # alice sends — her own message is now "unread" (cursor didn't advance)
-  run chat send --as alice --chat test-chat "first from alice"
+  run chat send --as alice --chat test-chat --msg "first from alice"
   [ "$status" -eq 0 ]
 
   # alice sends again — guard should NOT block (only own messages are unread)
-  run chat send --as alice --chat test-chat "second from alice"
+  run chat send --as alice --chat test-chat --msg "second from alice"
   [ "$status" -eq 0 ]
   grep -q "second from alice" "$CHAT_FILE"
 }
@@ -323,13 +323,18 @@ load test_helper
   send_message "bob" "hey alice"
 
   # alice sends with --force to bypass the guard
-  run chat send --as alice --chat test-chat --force "replying without reading"
+  run chat send --as alice --chat test-chat --force --msg "replying without reading"
   [ "$status" -eq 0 ]
 
   # alice's cursor should NOT have advanced — bob's message is still unread
   run chat read test-chat --as alice
   [ "$status" -eq 0 ]
   [[ "$output" == *"hey alice"* ]]
+}
+
+@test "task send: bare token errors instead of sending" {
+  run chat send den
+  [ "$status" -ne 0 ]
 }
 
 # ============================================================================
@@ -351,7 +356,7 @@ load test_helper
   run chat sig --as alice "sent from pi"
   [ "$status" -eq 0 ]
 
-  run chat send --as alice --chat test-chat "hello"
+  run chat send --as alice --chat test-chat --msg "hello"
   [ "$status" -eq 0 ]
   grep -q "hello" "$CHAT_FILE"
   grep -q '^--$' "$CHAT_FILE"
@@ -366,7 +371,7 @@ load test_helper
   [ "$status" -eq 0 ]
   [[ "$output" == *"Signature cleared for alice."* ]]
 
-  run chat send --as alice --chat test-chat "hello"
+  run chat send --as alice --chat test-chat --msg "hello"
   [ "$status" -eq 0 ]
   grep -q "hello" "$CHAT_FILE"
   ! grep -q "sent from pi" "$CHAT_FILE"
@@ -1088,7 +1093,7 @@ assert 'unread' not in data, f'unread should not be present without --as, got: {
 }
 
 @test "task send: creates channel that did not exist" {
-  run chat send --as alice --chat brand-new-channel "first message"
+  run chat send --as alice --chat brand-new-channel --msg "first message"
   [ "$status" -eq 0 ]
   [ -f "$CHAT_DATA_DIR/brand-new-channel.md" ]
   grep -q "first message" "$CHAT_DATA_DIR/brand-new-channel.md"

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -337,6 +337,12 @@ load test_helper
   [ "$status" -ne 0 ]
 }
 
+@test "task send: omitted --msg ignores stale usage_msg env" {
+  usage_msg="stale inherited message" run chat send --as alice --chat test-chat
+  [ "$status" -ne 0 ]
+  ! grep -q "stale inherited message" "$CHAT_FILE"
+}
+
 # ============================================================================
 # sig task
 # ============================================================================


### PR DESCRIPTION
## Summary

Replace the positional `<message>` arg in `chat send` with an explicit `--msg` flag.
The old `-`-for-stdin convention is replaced with auto-detecting a pipe (`! -t 0`).
A bare token like `chat send den` now errors instead of silently sending "den".

Closes #23.

## Files changed

| File | Change |
|------|--------|
| `.mise/tasks/send` | Replace `#USAGE arg "<message>"` with `#USAGE flag "--msg <msg>"`. Replace `message="${usage_message}"` + `-`-for-stdin with `$usage_msg` / pipe detection / error. Update 4 `#USAGE example` lines. |
| `.mise/tasks/readme` | Add `--check` flag forwarding and `CALLER_PWD` export (was writing README.md to the readme package dir instead of the chat repo). |
| `README.tsx` | Update quick-start example from `chat send "..."` to `chat send --msg "..."`. |
| `README.md` | Regenerated from README.tsx. |
| `test/tasks.bats` | Update all 24 `run chat send` invocations to `--msg` syntax. Add regression test `"task send: bare token errors instead of sending"`. |

## New tests

- `task send: bare token errors instead of sending` — asserts `chat send den` exits non-zero

## Test results

- **Baseline:** 187/187 passing
- **After changes:** 188/188 passing (1 new regression test)
- **CI gate:** `mise run readme -- --check` passes

## Design decision

Option **(a) — clean break** was chosen over (b) gradual deprecation or (c) collision guard.
The positional message was a footgun that burned real users (Baby Joel session 75).
A clean, unambiguous `send` contract is worth the syntax break.