### PR TITLE
ci: align validation with template

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,16 @@ jobs:
         with:
           install: true
 
+      - name: Check whitespace
+        run: git diff --check
+
       - name: Run tests
         run: mise run test
+
+      - name: Run codebase lints
+        run: codebase lint "$PWD"
+
+      - name: Check README.md is up to date
+        uses: KnickKnackLabs/readme@v0.3.1
+        with:
+          check: true

--- a/.mise/tasks/readme
+++ b/.mise/tasks/readme
@@ -5,7 +5,6 @@
 set -euo pipefail
 
 cd "$MISE_CONFIG_ROOT"
-export CALLER_PWD="$MISE_CONFIG_ROOT"
 
 args=()
 [ "${usage_check:-false}" = "true" ] && args+=(--check)

--- a/mise.toml
+++ b/mise.toml
@@ -12,8 +12,18 @@ gum = "latest"
 uv = "latest"
 bats = "1.13.0"
 "shiv:blobs" = "0.1"
-"shiv:codebase" = "0.2.0"                  # Codebase linting + migrations
-"shiv:readme" = "0.1.1"
+"shiv:codebase" = "0.3"                    # Codebase linting + migrations
+"shiv:readme" = "0.3"
 
 [_.codebase]
-lint = ["mise-settings", "gum-table", "bats-test-helper", "bats-test-task", "mcr-scope", "or-true", "shellcheck"]
+lint = [
+  "mise-settings",
+  "gum-table",
+  "bats-test-helper",
+  "bats-test-task",
+  "mcr-scope",
+  "or-true",
+  "shellcheck",
+  "caller-pwd-contract",
+  "github-actions",
+]


### PR DESCRIPTION
## Summary

Align chat's hosted validation with the template CI pattern before reviewing the higher-risk chat format migration PR.

Changes:
- add hosted CI gates for `git diff --check`, `codebase lint "$PWD"`, and generated README drift;
- bump `shiv:codebase` and `shiv:readme` to `0.3` minor streams;
- enable the newer `caller-pwd-contract` and `github-actions` codebase lint rules;
- remove the hidden readme task's legacy generic `CALLER_PWD` export and let the modern `readme` shim provide its package-scoped caller env.

## Validation

- `bash -n .mise/tasks/readme`
- `codebase lint "$PWD"` — all 9 configured rules passed
- `mise run readme --check`
- `mise run test` — 189 BATS
- `git diff --check`
