### PR TITLE
feat: add chat wait predicates and tui cockpit

### DIFF
--- a/.mise/tasks/clear
+++ b/.mise/tasks/clear
@@ -36,13 +36,13 @@ cp "$CHAT_FILE" "$archive_file"
 echo "Archived to: $archive_file"
 
 # Reset chat
-cat > "$CHAT_FILE" <<EOF
+cat > "$CHAT_FILE" <<CHAT_FILE_TEMPLATE
 # ${CHAT_NAME}
 
 Shared communication channel. Keep messages short (<10 lines). For longer content, write to \`/tmp/chat-attachment-<timestamp>.md\` and reference it here.
 
 ---
-EOF
+CHAT_FILE_TEMPLATE
 
 # Reset cursors for this chat
 rm -f "$CHAT_CURSOR_DIR"/*

--- a/.mise/tasks/tui/_default
+++ b/.mise/tasks/tui/_default
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#MISE description="Open a zellij chat cockpit"
+#USAGE arg "[chat]" default="" help="Initial chat channel (default: $CHAT_CHANNEL or default)"
+#USAGE flag "--as <as>" default="" help="Your identity (default: $CHAT_IDENTITY)"
+#USAGE flag "--session <session>" default="chat-tui" help="Zellij session name"
+#USAGE flag "--fresh" default=#false help="Kill/delete an existing session before opening"
+#USAGE flag "--last <last>" default="80" help="Messages to show in the live view"
+#USAGE flag "--poll <seconds>" default="2" help="Live view refresh interval"
+#USAGE flag "--dry-run" default=#false help="Prepare state and print the launch command without attaching"
+#USAGE example "chat tui --as alice" header="Open the default chat cockpit"
+#USAGE example "chat tui fold --as alice" header="Open a specific channel"
+#USAGE example "chat tui fold --as alice --fresh" header="Recreate the zellij session with the current layout"
+set -euo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/chat.sh"
+
+chat_resolve "${usage_chat:-}"
+chat_require_file
+chat_require_identity "${usage_as:-}"
+identity="$CHAT_IDENTITY"
+
+session="${usage_session:-chat-tui}"
+fresh="${usage_fresh:-false}"
+last="${usage_last:-80}"
+poll="${usage_poll:-2}"
+dry_run="${usage_dry_run:-false}"
+
+case "$last" in
+  ''|*[!0-9]*) echo "Error: --last must be a non-negative integer (got: $last)" >&2; exit 1 ;;
+esac
+case "$poll" in
+  ''|*[!0-9]*) echo "Error: --poll must be a positive integer (got: $poll)" >&2; exit 1 ;;
+  0) echo "Error: --poll must be a positive integer (got: 0)" >&2; exit 1 ;;
+esac
+
+safe_session=$(printf '%s' "$session" | tr -c 'A-Za-z0-9_.-' '_')
+state_dir="$CHAT_DATA_DIR/.tui/$safe_session"
+mkdir -p "$state_dir"
+printf '%s\n' "$CHAT_NAME" > "$state_dir/channel"
+printf '%s\n' "$identity" > "$state_dir/identity"
+
+export CHAT_TUI_ROOT="$MISE_CONFIG_ROOT"
+export CHAT_TUI_STATE_DIR="$state_dir"
+export CHAT_CHANNEL="$CHAT_NAME"
+export CHAT_IDENTITY="$identity"
+export CHAT_TUI_LAST="$last"
+export CHAT_TUI_POLL="$poll"
+
+layout="$MISE_CONFIG_ROOT/lib/tui/layout.kdl"
+
+if [ "$dry_run" = "true" ]; then
+  printf 'prepared chat tui session %s (chat:%s as:%s)\n' "$session" "$CHAT_NAME" "$identity"
+  printf 'state_dir=%s\n' "$state_dir"
+  printf 'layout=%s\n' "$layout"
+  printf 'pane_tasks=tui:rooms,tui:view,tui:compose\n'
+  printf 'command=zellij attach --create --forget --force-run-commands %s options --default-layout %s\n' "$session" "$layout"
+  exit 0
+fi
+
+if [ "$fresh" = "true" ]; then
+  if ! zellij kill-session "$session" >/dev/null 2>&1; then
+    : # session may not exist yet
+  fi
+  if ! zellij delete-session "$session" >/dev/null 2>&1; then
+    : # saved session may not exist yet
+  fi
+fi
+
+printf 'opening zellij session %s (chat:%s as:%s)\n' "$session" "$CHAT_NAME" "$identity"
+exec zellij attach --create --forget --force-run-commands "$session" options --default-layout "$layout"

--- a/.mise/tasks/tui/compose
+++ b/.mise/tasks/tui/compose
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#MISE description="Open the compose pane for chat tui"
+#USAGE flag "--dry-run" default=#false help="Print the compose target and exit before opening gum write"
+set -euo pipefail
+
+root="$MISE_CONFIG_ROOT"
+# shellcheck source=lib/tui/common.sh
+source "$root/lib/tui/common.sh"
+
+dry_run="${usage_dry_run:-false}"
+height="${CHAT_TUI_COMPOSE_HEIGHT:-6}"
+chat_tui_ensure_state
+
+try_clear() {
+  if ! clear; then
+    : # clear can fail when TERM is missing or unsupported
+  fi
+}
+
+while true; do
+  channel="$(chat_tui_current_channel)"
+  identity="$(chat_tui_current_identity)"
+
+  try_clear
+  chat_tui_gum style --bold --foreground 212 -- "compose → chat:$channel as:$identity"
+  chat_tui_gum style --foreground 240 -- "Multiline input via gum write. Empty drafts are skipped. Ctrl-C exits this pane."
+  printf '\n'
+
+  if [ "$dry_run" = "true" ]; then
+    exit 0
+  fi
+
+  if ! body="$(chat_tui_gum write \
+    --height="$height" \
+    --header="Message to #$channel as $identity" \
+    --placeholder="Write a message…" \
+    --show-line-numbers)"; then
+    printf 'composer exited\n'
+    exit 0
+  fi
+
+  if [ -z "$(printf '%s' "$body" | tr -d '[:space:]')" ]; then
+    chat_tui_gum style --foreground 240 -- "empty draft skipped"
+    sleep 1
+    continue
+  fi
+
+  if printf '%s' "$body" | chat_tui_clean send --chat "$channel" --as "$identity" --force; then
+    chat_tui_gum style --foreground 46 -- "sent to #$channel"
+  else
+    chat_tui_gum style --foreground 196 -- "send failed"
+  fi
+  sleep 1
+done

--- a/.mise/tasks/tui/compose
+++ b/.mise/tasks/tui/compose
@@ -12,7 +12,7 @@ height="${CHAT_TUI_COMPOSE_HEIGHT:-6}"
 chat_tui_ensure_state
 
 try_clear() {
-  if ! clear; then
+  if ! clear 2>/dev/null; then
     : # clear can fail when TERM is missing or unsupported
   fi
 }

--- a/.mise/tasks/tui/rooms
+++ b/.mise/tasks/tui/rooms
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#MISE description="Select the active room for chat tui"
+#USAGE flag "--print" default=#false help="Print selectable rooms once instead of opening fzf"
+set -euo pipefail
+
+root="$MISE_CONFIG_ROOT"
+# shellcheck source=lib/tui/common.sh
+source "$root/lib/tui/common.sh"
+
+print_once="${usage_print:-false}"
+chat_tui_ensure_state
+
+try_clear() {
+  if ! clear; then
+    : # clear can fail when TERM is missing or unsupported
+  fi
+}
+
+while true; do
+  identity="$(chat_tui_current_identity)"
+  current="$(chat_tui_current_channel)"
+  tmp="$(mktemp "${TMPDIR:-/tmp}/chat-tui-rooms.XXXXXX")"
+  err="$tmp.err"
+  trap 'rm -f "$tmp" "$err"' EXIT
+
+  if ! chat_tui_clean list --json --as "$identity" > "$tmp" 2> "$err"; then
+    try_clear
+    printf 'chat list failed for identity %s:\n' "$identity" >&2
+    cat "$err" >&2
+    rm -f "$tmp" "$err"
+    trap - EXIT
+    sleep 3
+    continue
+  fi
+
+  rooms="$(
+    jq -r --arg current "$current" '
+      .[]
+      | if .name == $current then "▶ " + .name else "  " + .name end
+    ' "$tmp"
+  )"
+
+  if [ "$print_once" = "true" ]; then
+    printf '%s\n' "$rooms"
+    rm -f "$tmp" "$err"
+    trap - EXIT
+    exit 0
+  fi
+
+  if ! selection="$(
+    printf '%s\n' "$rooms" |
+      fzf \
+        --no-border \
+        --layout=reverse \
+        --prompt="" \
+        --header="Select chat room (Enter). Ctrl-C quits picker."
+  )"; then
+    printf 'room picker exited\n'
+    exit 0
+  fi
+
+  channel="$(printf '%s\n' "$selection" | sed 's/^▶ //; s/^  //')"
+  if [ -n "$channel" ]; then
+    chat_tui_write_state channel "$channel"
+    if command -v gum >/dev/null 2>&1; then
+      chat_tui_gum style --foreground 46 -- "selected #$channel"
+    else
+      printf 'selected #%s\n' "$channel"
+    fi
+  fi
+
+  rm -f "$tmp" "$err"
+  trap - EXIT
+done

--- a/.mise/tasks/tui/rooms
+++ b/.mise/tasks/tui/rooms
@@ -11,7 +11,7 @@ print_once="${usage_print:-false}"
 chat_tui_ensure_state
 
 try_clear() {
-  if ! clear; then
+  if ! clear 2>/dev/null; then
     : # clear can fail when TERM is missing or unsupported
   fi
 }

--- a/.mise/tasks/tui/view
+++ b/.mise/tasks/tui/view
@@ -23,7 +23,7 @@ try_tput() {
 }
 
 try_clear() {
-  if ! clear; then
+  if ! clear 2>/dev/null; then
     : # clear can fail when TERM is missing or unsupported
   fi
 }

--- a/.mise/tasks/tui/view
+++ b/.mise/tasks/tui/view
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#MISE description="Render the live message pane for chat tui"
+#USAGE flag "--once" default=#false help="Render once and exit instead of polling"
+set -euo pipefail
+
+root="$MISE_CONFIG_ROOT"
+# shellcheck source=lib/tui/common.sh
+source "$root/lib/tui/common.sh"
+
+once="${usage_once:-false}"
+last="${CHAT_TUI_LAST:-80}"
+poll="${CHAT_TUI_POLL:-2}"
+chat_tui_ensure_state
+
+hash_file() {
+  cksum "$1" | awk '{print $1":"$2}'
+}
+
+try_tput() {
+  if ! tput "$@" 2>/dev/null; then
+    : # terminal capability may be unavailable in non-interactive panes/tests
+  fi
+}
+
+try_clear() {
+  if ! clear; then
+    : # clear can fail when TERM is missing or unsupported
+  fi
+}
+
+render_once() {
+  local channel="$1"
+  local identity="$2"
+
+  if command -v gum >/dev/null 2>&1; then
+    chat_tui_gum style --bold --foreground 212 -- "chat:$channel as:$identity"
+    chat_tui_gum style --foreground 240 -- "peek-reading last $last messages · refresh ${poll}s · terminal autowrap off · Ctrl-C exits this pane"
+  else
+    printf 'chat:%s as:%s\n' "$channel" "$identity"
+    printf 'peek-reading last %s messages · refresh %ss · terminal autowrap off · Ctrl-C exits this pane\n' "$last" "$poll"
+  fi
+  printf '\n'
+
+  if json="$(chat_tui_clean read "$channel" --as "$identity" --peek --all --last "$last" --json --id 2>&1)"; then
+    if [ -n "$json" ]; then
+      printf '%s\n' "$json" | "$root/lib/tui/render-messages"
+    fi
+  else
+    printf 'chat read failed:\n%s\n' "$json" >&2
+  fi
+
+  printf '\n'
+  if command -v gum >/dev/null 2>&1; then
+    chat_tui_gum style --foreground 240 -- "state: $(chat_tui_state_path channel)"
+  else
+    printf 'state: %s\n' "$(chat_tui_state_path channel)"
+  fi
+}
+
+tmp="$(mktemp "${TMPDIR:-/tmp}/chat-tui-view.XXXXXX")"
+cleanup() {
+  rm -f "$tmp"
+  try_tput smam
+  try_tput cnorm
+}
+trap cleanup EXIT INT TERM
+
+last_hash=""
+try_tput civis
+try_tput rmam
+try_clear
+
+while true; do
+  channel="$(chat_tui_current_channel)"
+  identity="$(chat_tui_current_identity)"
+
+  if render_once "$channel" "$identity" > "$tmp"; then
+    hash="$(hash_file "$tmp")"
+    if [ "$hash" != "$last_hash" ]; then
+      try_tput cup 0 0
+      cat "$tmp"
+      try_tput ed
+      last_hash="$hash"
+    fi
+  else
+    try_tput cup 0 0
+    printf 'view render failed\n'
+    try_tput ed
+  fi
+
+  if [ "$once" = "true" ]; then
+    exit 0
+  fi
+
+  sleep "$poll"
+done

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -100,9 +100,9 @@ _count_other_senders() {
     if [ "$sender" != "$self" ]; then
       count=$((count + 1))
     fi
-  done <<EOF_HEADERS
+  done <<CHAT_HEADERS
 $headers
-EOF_HEADERS
+CHAT_HEADERS
   echo "$count"
 }
 
@@ -112,48 +112,53 @@ _count_matching_messages() {
   local sender_filter="$3"
   local mention_filter="$4"
 
+  local awk_program
+  awk_program=$(cat <<'AWK'
+function has_mention(text, identity,    needle, start, pos, after) {
+  if (identity == "") return 1
+  needle = "@" identity
+  start = 1
+  while ((pos = index(substr(text, start), needle)) > 0) {
+    pos = start + pos - 1
+    after = substr(text, pos + length(needle), 1)
+    if (after == "" || after !~ /[[:alnum:]_.-]/) return 1
+    start = pos + length(needle)
+  }
+  return 0
+}
+function finish_message() {
+  if (!in_message) return
+  if (self != "" && sender == self) return
+  if (sender_filter != "" && sender != sender_filter) return
+  if (mention_filter != "" && !has_mention(body, mention_filter)) return
+  count++
+}
+/^### / {
+  finish_message()
+  in_message = 1
+  sender = $0
+  sub(/^### /, "", sender)
+  sub(/ — .*/, "", sender)
+  body = ""
+  next
+}
+in_message {
+  body = body $0 "\n"
+}
+END {
+  finish_message()
+  print count + 0
+}
+AWK
+)
+
   awk \
     -v self="$self" \
     -v sender_filter="$sender_filter" \
-    -v mention_filter="$mention_filter" '
-      function has_mention(text, identity,    needle, start, pos, after) {
-        if (identity == "") return 1
-        needle = "@" identity
-        start = 1
-        while ((pos = index(substr(text, start), needle)) > 0) {
-          pos = start + pos - 1
-          after = substr(text, pos + length(needle), 1)
-          if (after == "" || after !~ /[[:alnum:]_.-]/) return 1
-          start = pos + length(needle)
-        }
-        return 0
-      }
-      function finish_message() {
-        if (!in_message) return
-        if (self != "" && sender == self) return
-        if (sender_filter != "" && sender != sender_filter) return
-        if (mention_filter != "" && !has_mention(body, mention_filter)) return
-        count++
-      }
-      /^### / {
-        finish_message()
-        in_message = 1
-        sender = $0
-        sub(/^### /, "", sender)
-        sub(/ — .*/, "", sender)
-        body = ""
-        next
-      }
-      in_message {
-        body = body $0 "\n"
-      }
-      END {
-        finish_message()
-        print count + 0
-      }
-    ' <<EOF_CONTENT
+    -v mention_filter="$mention_filter" \
+    "$awk_program" <<CHAT_CONTENT
 $content
-EOF_CONTENT
+CHAT_CONTENT
 }
 
 _has_enough_messages() {

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -116,11 +116,23 @@ _count_matching_messages() {
     -v self="$self" \
     -v sender_filter="$sender_filter" \
     -v mention_filter="$mention_filter" '
+      function has_mention(text, identity,    needle, start, pos, after) {
+        if (identity == "") return 1
+        needle = "@" identity
+        start = 1
+        while ((pos = index(substr(text, start), needle)) > 0) {
+          pos = start + pos - 1
+          after = substr(text, pos + length(needle), 1)
+          if (after == "" || after !~ /[[:alnum:]_.-]/) return 1
+          start = pos + length(needle)
+        }
+        return 0
+      }
       function finish_message() {
         if (!in_message) return
         if (self != "" && sender == self) return
         if (sender_filter != "" && sender != sender_filter) return
-        if (mention_filter != "" && index(body, "@" mention_filter) == 0) return
+        if (mention_filter != "" && !has_mention(body, mention_filter)) return
         count++
       }
       /^### / {

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -1,38 +1,72 @@
 #!/usr/bin/env bash
 #MISE description="Wait for a new message"
-#USAGE arg "[chat]" help="Chat name (default: $CHAT_CHANNEL or default)"
-#USAGE flag "--as <as>" help="Your identity — ignores own messages (default: $CHAT_IDENTITY)"
-#USAGE flag "--timeout <seconds>" help="Max seconds to wait (0 = forever)" default="120"
-#USAGE flag "--forever" help="Wait indefinitely (shorthand for --timeout 0)"
-#USAGE flag "--batch <batch>" help="Wait for N messages from others before waking (default: 1)" default="1"
+#USAGE arg "[chat]" default="" help="Chat name (default: $CHAT_CHANNEL or default)"
+#USAGE flag "--as <as>" default="" help="Your identity — ignores own messages (default: $CHAT_IDENTITY)"
+#USAGE flag "--by <by>" default="" help="Only wake on messages from this sender"
+#USAGE flag "--from <from>" default="" help="Alias for --by"
+#USAGE flag "--mention <identity>" default="" help="Only wake on messages mentioning @identity"
+#USAGE flag "--mentioned" default=#false help="Only wake on messages mentioning the waiting identity"
+#USAGE flag "--timeout <seconds>" default="120" help="Max seconds to wait (0 = forever)"
+#USAGE flag "--forever" default=#false help="Wait indefinitely (shorthand for --timeout 0)"
+#USAGE flag "--poll <seconds>" default="3" help="Polling interval in seconds"
+#USAGE flag "--batch <batch>" default="1" help="Wait for N matching messages before waking"
+#USAGE flag "--loop" default=#false help="Keep waiting after each matching batch"
 #USAGE example "chat wait --as alice" header="Wait for any new message"
 #USAGE example "chat wait ops --as alice" header="Wait for a message in a specific chat"
-#USAGE example "chat wait --as alice --timeout 60" header="Wait with a 60-second timeout"
-#USAGE example "chat wait --as alice --forever" header="Wait indefinitely"
+#USAGE example "chat wait --as alice --by or --mentioned --forever" header="Wait until Or mentions you"
+#USAGE example "chat wait --as alice --mention brownie --timeout 60" header="Wait up to 60 seconds for a mention"
 #USAGE example "chat wait --as alice --batch 3" header="Wait for 3 messages from others"
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/chat.sh"
 chat_resolve "${usage_chat:-}"
 chat_require_file
 
-# Identity optional for wait — but needed to ignore own messages
 chat_resolve_identity "${usage_as:-}"
 agent="$CHAT_IDENTITY"
-timeout="${usage_timeout:-120}"
-batch="${usage_batch:-1}"
-if ! [[ "$batch" =~ ^[1-9][0-9]*$ ]]; then
-  echo "Error: --batch must be a positive integer (got: $batch)" >&2
+
+by="${usage_by:-}"
+from_alias="${usage_from:-}"
+if [ -n "$by" ] && [ -n "$from_alias" ] && [ "$by" != "$from_alias" ]; then
+  echo "Error: use either --by or --from, not both." >&2
   exit 1
 fi
-# --forever overrides --timeout
+[ -n "$by" ] || by="$from_alias"
+
+mention="${usage_mention:-}"
+mentioned="${usage_mentioned:-false}"
+if [ "$mentioned" = "true" ]; then
+  if [ -z "$agent" ]; then
+    echo "Error: --mentioned requires an identity. Use --as <name> or set \$CHAT_IDENTITY." >&2
+    exit 1
+  fi
+  if [ -n "$mention" ] && [ "$mention" != "$agent" ]; then
+    echo "Error: use either --mention or --mentioned, not both." >&2
+    exit 1
+  fi
+  mention="$agent"
+fi
+
+timeout="${usage_timeout:-120}"
+poll="${usage_poll:-3}"
+batch="${usage_batch:-1}"
+loop="${usage_loop:-false}"
+
 if [ "${usage_forever:-false}" = "true" ]; then
   timeout=0
 fi
 
-# Use cursor (last-read position) instead of current line count.
-# This way we catch messages sent BEFORE wait started but AFTER
-# the agent's last `read`.
+case "$timeout" in
+  ''|*[!0-9]*) echo "Error: --timeout must be a non-negative integer (got: $timeout)" >&2; exit 1 ;;
+esac
+case "$poll" in
+  ''|*[!0-9]*) echo "Error: --poll must be a positive integer (got: $poll)" >&2; exit 1 ;;
+  0) echo "Error: --poll must be a positive integer (got: 0)" >&2; exit 1 ;;
+esac
+case "$batch" in
+  ''|0|*[!0-9]*) echo "Error: --batch must be a positive integer (got: $batch)" >&2; exit 1 ;;
+esac
+
 if [ -n "$agent" ]; then
   cursor=$(chat_get_cursor "$agent")
 else
@@ -40,105 +74,150 @@ else
 fi
 total=$(chat_line_count)
 
-# Edge case: cursor beyond file length (e.g., chat was truncated/cleared)
 if [ "$cursor" -gt "$total" ]; then
   cursor="$total"
 fi
 
-# Edge case: cursor=0 means agent has never read this chat.
-# Don't dump the entire history — start from current position.
 if [ -n "$agent" ] && [ "$cursor" -eq 0 ]; then
   cursor="$total"
   chat_set_cursor "$agent"
 fi
 
-# Count messages from senders other than the given agent.
-# Usage: _count_other_senders "content" "agent_name"
-# Prints the count to stdout.
 _count_other_senders() {
   local content="$1"
   local self="$2"
   local headers
-  headers=$(echo "$content" | grep '^### ') || headers=""
+  headers=$(printf '%s\n' "$content" | grep '^### ') || headers=""
   [ -z "$headers" ] && { echo "0"; return; }
   if [ -z "$self" ]; then
-    # no identity → count all messages
-    echo "$headers" | wc -l | tr -d ' '
+    printf '%s\n' "$headers" | wc -l | tr -d ' '
     return
   fi
   local count=0
+  local header sender
   while IFS= read -r header; do
-    local sender
-    sender=$(echo "$header" | sed -E 's/^### (.+) — .+$/\1/')
+    sender=$(printf '%s\n' "$header" | sed -E 's/^### (.+) — .+$/\1/')
     if [ "$sender" != "$self" ]; then
       count=$((count + 1))
     fi
-  done <<< "$headers"
+  done <<EOF_HEADERS
+$headers
+EOF_HEADERS
   echo "$count"
 }
 
-# Check whether content has enough messages from others to meet the batch threshold.
-# Usage: _has_enough_messages "content" "agent_name" batch_count
-# Returns 0 if count >= batch, 1 otherwise.
+_count_matching_messages() {
+  local content="$1"
+  local self="$2"
+  local sender_filter="$3"
+  local mention_filter="$4"
+
+  awk \
+    -v self="$self" \
+    -v sender_filter="$sender_filter" \
+    -v mention_filter="$mention_filter" '
+      function finish_message() {
+        if (!in_message) return
+        if (self != "" && sender == self) return
+        if (sender_filter != "" && sender != sender_filter) return
+        if (mention_filter != "" && index(body, "@" mention_filter) == 0) return
+        count++
+      }
+      /^### / {
+        finish_message()
+        in_message = 1
+        sender = $0
+        sub(/^### /, "", sender)
+        sub(/ — .*/, "", sender)
+        body = ""
+        next
+      }
+      in_message {
+        body = body $0 "\n"
+      }
+      END {
+        finish_message()
+        print count + 0
+      }
+    ' <<EOF_CONTENT
+$content
+EOF_CONTENT
+}
+
 _has_enough_messages() {
   local content="$1"
   local self="$2"
-  local threshold="$3"
+  local sender_filter="$3"
+  local mention_filter="$4"
+  local threshold="$5"
   local count
-  count=$(_count_other_senders "$content" "$self")
+  count=$(_count_matching_messages "$content" "$self" "$sender_filter" "$mention_filter")
   [ "$count" -ge "$threshold" ]
 }
 
-# Check if there are already unread messages before we start polling
-if [ "$cursor" -lt "$total" ]; then
+print_wake() {
+  local content="$1"
+  echo "New messages:"
+  printf '%s\n' "$content" | chat_format_messages
+}
+
+check_once() {
+  local current_lines new_content
+  current_lines=$(chat_line_count)
+  if [ "$current_lines" -le "$cursor" ]; then
+    return 1
+  fi
+
   new_content=$(tail -n +"$((cursor + 1))" "$CHAT_FILE")
-
-  if _has_enough_messages "$new_content" "$agent" "$batch"; then
-    echo "New messages:"
-    echo "$new_content" | chat_format_messages
-    [ -n "$agent" ] && chat_set_cursor "$agent"
-    exit 0
+  if _has_enough_messages "$new_content" "$agent" "$by" "$mention" "$batch"; then
+    print_wake "$new_content"
+    if [ -n "$agent" ]; then
+      chat_set_cursor "$agent"
+      cursor=$(chat_get_cursor "$agent")
+    else
+      cursor="$current_lines"
+    fi
+    return 0
   fi
 
-  # Not enough messages yet (or only own) — advance cursor past own and continue
-  # Only advance if there are no other-sender messages at all (pure own messages).
-  # If there are some but not enough, keep cursor to accumulate toward batch.
   if [ "$(_count_other_senders "$new_content" "$agent")" -eq 0 ]; then
-    [ -n "$agent" ] && chat_set_cursor "$agent"
-    cursor="$total"
+    if [ -n "$agent" ]; then
+      chat_set_cursor "$agent"
+      cursor=$(chat_get_cursor "$agent")
+    else
+      cursor="$current_lines"
+    fi
   fi
+  return 1
+}
+
+if [ "$cursor" -lt "$total" ] && check_once; then
+  [ "$loop" = "true" ] || exit 0
 fi
+
+descriptor="messages in ${CHAT_NAME}"
+[ -n "$agent" ] && descriptor="$descriptor (ignoring own)"
+[ -n "$by" ] && descriptor="$descriptor from $by"
+[ -n "$mention" ] && descriptor="$descriptor mentioning @$mention"
+echo "Waiting for ${descriptor}... (timeout: ${timeout}s)"
 
 elapsed=0
-interval=3
-
-if [ -n "$agent" ]; then
-  echo "Waiting for messages in ${CHAT_NAME} (ignoring own)... (timeout: ${timeout}s)"
-else
-  echo "Waiting for messages in ${CHAT_NAME}... (timeout: ${timeout}s)"
-fi
-
 while true; do
-  current_lines=$(chat_line_count)
-
-  if [ "$current_lines" -gt "$cursor" ]; then
-    new_content=$(tail -n +"$((cursor + 1))" "$CHAT_FILE")
-
-    if _has_enough_messages "$new_content" "$agent" "$batch"; then
-      echo ""
-      echo "New messages:"
-      echo "$new_content" | chat_format_messages
-      [ -n "$agent" ] && chat_set_cursor "$agent"
+  if check_once; then
+    if [ "$loop" != "true" ]; then
       exit 0
     fi
+    echo ""
+    echo "Waiting for next matching batch..."
+    elapsed=0
   fi
 
   if [ "$timeout" -gt 0 ] && [ "$elapsed" -ge "$timeout" ]; then
     echo ""
-    echo "Timed out after ${timeout}s — no new messages."
+    echo "Timed out after ${timeout}s — no matching messages."
     exit 1
   fi
 
-  sleep "$interval"
-  elapsed=$((elapsed + interval))
+  sleep "$poll"
+  elapsed=$((elapsed + poll))
 done

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agents on the same machine exchange short messages through a shared channel.
 No server. No daemon. Just files, cursors, and bash.
 
 ![lang: bash](https://img.shields.io/badge/lang-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 199 passing](https://img.shields.io/badge/tests-199%20passing-brightgreen?style=flat)](test/)
+[![tests: 201 passing](https://img.shields.io/badge/tests-201%20passing-brightgreen?style=flat)](test/)
 ![deps: jq + gum + fzf + zellij + blobs](https://img.shields.io/badge/deps-jq%20%2B%20gum%20%2B%20fzf%20%2B%20zellij%20%2B%20blobs-blue?style=flat)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)
 
@@ -93,7 +93,7 @@ FYI — just pushed the load testing scenarios to the note.
 
 ## Commands
 
-**13 commands**, each a standalone bash script in `.mise/tasks/`:
+**18 commands**, each a standalone bash script in `.mise/tasks/`:
 
 
 ### chat clear
@@ -107,6 +107,32 @@ chat clear [--yes] [chat]
 | Flag    | Description       | Default |
 | ------- | ----------------- | ------- |
 | `--yes` | Skip confirmation | —       |
+
+
+### chat cursor:clear
+
+Clear your cursor (mark everything as unread)
+
+```
+chat cursor:clear [--as <as>] [chat]
+```
+
+| Flag   | Description                             | Default |
+| ------ | --------------------------------------- | ------- |
+| `--as` | Your identity (default: $CHAT_IDENTITY) | —       |
+
+
+### chat cursor:undo
+
+Undo the last cursor advance (restore previous read position)
+
+```
+chat cursor:undo [--as <as>] [chat]
+```
+
+| Flag   | Description                             | Default |
+| ------ | --------------------------------------- | ------- |
+| `--as` | Your identity (default: $CHAT_IDENTITY) | —       |
 
 
 ### chat export
@@ -261,6 +287,45 @@ chat tui [--as <as>] [--session <session>] [--fresh] [--last <last>] [--poll <se
 | `--dry-run` | Prepare state and print the launch command without attaching | —          |
 
 
+### chat tui:compose
+
+Open the compose pane for chat tui
+
+```
+chat tui:compose [--dry-run]
+```
+
+| Flag        | Description                                                | Default |
+| ----------- | ---------------------------------------------------------- | ------- |
+| `--dry-run` | Print the compose target and exit before opening gum write | —       |
+
+
+### chat tui:rooms
+
+Select the active room for chat tui
+
+```
+chat tui:rooms [--print]
+```
+
+| Flag      | Description                                        | Default |
+| --------- | -------------------------------------------------- | ------- |
+| `--print` | Print selectable rooms once instead of opening fzf | —       |
+
+
+### chat tui:view
+
+Render the live message pane for chat tui
+
+```
+chat tui:view [--once]
+```
+
+| Flag     | Description                             | Default |
+| -------- | --------------------------------------- | ------- |
+| `--once` | Render once and exit instead of polling | —       |
+
+
 ### chat unread
 
 Count total unread messages across all channels
@@ -384,7 +449,7 @@ cd chat && mise trust && mise install
 mise run test
 ```
 
-199 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
+201 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Agents on the same machine exchange short messages through a shared channel.
 No server. No daemon. Just files, cursors, and bash.
 
 ![lang: bash](https://img.shields.io/badge/lang-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 189 passing](https://img.shields.io/badge/tests-189%20passing-brightgreen?style=flat)](test/)
-![deps: jq + gum + blobs](https://img.shields.io/badge/deps-jq%20%2B%20gum%20%2B%20blobs-blue?style=flat)
+[![tests: 199 passing](https://img.shields.io/badge/tests-199%20passing-brightgreen?style=flat)](test/)
+![deps: jq + gum + fzf + zellij + blobs](https://img.shields.io/badge/deps-jq%20%2B%20gum%20%2B%20fzf%20%2B%20zellij%20%2B%20blobs-blue?style=flat)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)
 
 </div>
@@ -43,6 +43,9 @@ chat read
 
 # Quick status overview
 chat status
+
+# Human-oriented live cockpit
+chat tui fold --as brownie
 ```
 
 ## How it works
@@ -90,7 +93,7 @@ FYI — just pushed the load testing scenarios to the note.
 
 ## Commands
 
-**12 commands**, each a standalone bash script in `.mise/tasks/`:
+**13 commands**, each a standalone bash script in `.mise/tasks/`:
 
 
 ### chat clear
@@ -240,6 +243,24 @@ chat test
 ```
 
 
+### chat tui
+
+Open a zellij chat cockpit
+
+```
+chat tui [--as <as>] [--session <session>] [--fresh] [--last <last>] [--poll <seconds>] [--dry-run] [chat]
+```
+
+| Flag        | Description                                                  | Default    |
+| ----------- | ------------------------------------------------------------ | ---------- |
+| `--as`      | Your identity (default: $CHAT_IDENTITY)                      | —          |
+| `--session` | Zellij session name                                          | `chat-tui` |
+| `--fresh`   | Kill/delete an existing session before opening               | —          |
+| `--last`    | Messages to show in the live view                            | `80`       |
+| `--poll`    | Live view refresh interval                                   | `2`        |
+| `--dry-run` | Prepare state and print the launch command without attaching | —          |
+
+
 ### chat unread
 
 Count total unread messages across all channels
@@ -260,15 +281,21 @@ chat unread [--as <as>] [--json] [--max-parallel <max_parallel>]
 Wait for a new message
 
 ```
-chat wait [--as <as>] [--timeout <seconds>] [--forever] [--batch <batch>] [chat]
+chat wait [--as <as>] [--by <by>] [--from <from>] [--mention <identity>] [--mentioned] [--timeout <seconds>] [--forever] [--poll <seconds>] [--batch <batch>] [--loop] [chat]
 ```
 
-| Flag        | Description                                                    | Default |
-| ----------- | -------------------------------------------------------------- | ------- |
-| `--as`      | Your identity — ignores own messages (default: $CHAT_IDENTITY) | —       |
-| `--timeout` | Max seconds to wait (0 = forever)                              | `120`   |
-| `--forever` | Wait indefinitely (shorthand for --timeout 0)                  | —       |
-| `--batch`   | Wait for N messages from others before waking (default: 1)     | `1`     |
+| Flag          | Description                                                    | Default |
+| ------------- | -------------------------------------------------------------- | ------- |
+| `--as`        | Your identity — ignores own messages (default: $CHAT_IDENTITY) | —       |
+| `--by`        | Only wake on messages from this sender                         | —       |
+| `--from`      | Alias for --by                                                 | —       |
+| `--mention`   | Only wake on messages mentioning @identity                     | —       |
+| `--mentioned` | Only wake on messages mentioning the waiting identity          | —       |
+| `--timeout`   | Max seconds to wait (0 = forever)                              | `120`   |
+| `--forever`   | Wait indefinitely (shorthand for --timeout 0)                  | —       |
+| `--poll`      | Polling interval in seconds                                    | `3`     |
+| `--batch`     | Wait for N matching messages before waking                     | `1`     |
+| `--loop`      | Keep waiting after each matching batch                         | —       |
 
 <br />
 
@@ -304,6 +331,7 @@ Git repository names are not used for implicit channel selection. Use `--chat fo
 - File-based — everything is readable plain text
 - Cursor-based unread tracking — simple line counting
 - Polling, not pushing — `chat wait` checks every 3s
+- TUI panes are mise subtasks — `chat tui:rooms`, `chat tui:view`, and `chat tui:compose` can run independently
 - Ephemeral — `chat clear` archives and resets
 
 
@@ -356,7 +384,7 @@ cd chat && mise trust && mise install
 mise run test
 ```
 
-189 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
+199 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agents on the same machine exchange short messages through a shared channel.
 No server. No daemon. Just files, cursors, and bash.
 
 ![lang: bash](https://img.shields.io/badge/lang-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 201 passing](https://img.shields.io/badge/tests-201%20passing-brightgreen?style=flat)](test/)
+[![tests: 203 passing](https://img.shields.io/badge/tests-203%20passing-brightgreen?style=flat)](test/)
 ![deps: jq + gum + fzf + zellij + blobs](https://img.shields.io/badge/deps-jq%20%2B%20gum%20%2B%20fzf%20%2B%20zellij%20%2B%20blobs-blue?style=flat)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)
 
@@ -449,7 +449,7 @@ cd chat && mise trust && mise install
 mise run test
 ```
 
-201 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
+203 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
 
 <br />
 

--- a/README.tsx
+++ b/README.tsx
@@ -111,7 +111,7 @@ const readme = (
       <Badges>
         <Badge label="lang" value="bash" color="4EAA25" logo="gnubash" logoColor="white" />
         <Badge label="tests" value={`${testCount} passing`} color="brightgreen" href="test/" />
-        <Badge label="deps" value="jq + gum + blobs" color="blue" />
+        <Badge label="deps" value="jq + gum + fzf + zellij + blobs" color="blue" />
         <Badge label="License" value="MIT" color="blue" />
       </Badges>
     </Center>
@@ -132,7 +132,10 @@ chat send --msg "Hey everyone, good morning!"
 chat read
 
 # Quick status overview
-chat status`}</CodeBlock>
+chat status
+
+# Human-oriented live cockpit
+chat tui fold --as brownie`}</CodeBlock>
     </Section>
 
     <Section title="How it works">
@@ -250,6 +253,7 @@ chat status`}</CodeBlock>
               <Item>{"File-based — everything is readable plain text"}</Item>
               <Item>{"Cursor-based unread tracking — simple line counting"}</Item>
               <Item>{"Polling, not pushing — "}<Code>chat wait</Code>{" checks every 3s"}</Item>
+              <Item>{"TUI panes are mise subtasks — "}<Code>chat tui:rooms</Code>{", "}<Code>chat tui:view</Code>{", and "}<Code>chat tui:compose</Code>{" can run independently"}</Item>
               <Item>{"Ephemeral — "}<Code>chat clear</Code>{" archives and resets"}</Item>
             </List>
           </HtmlTd>

--- a/lib/chat.sh
+++ b/lib/chat.sh
@@ -66,13 +66,13 @@ chat_require_file() {
 chat_init() {
   mkdir -p "$CHAT_DATA_DIR" "$CHAT_CURSOR_DIR"
   if [ ! -f "$CHAT_FILE" ]; then
-    cat > "$CHAT_FILE" <<EOF
+    cat > "$CHAT_FILE" <<CHAT_FILE_TEMPLATE
 # ${CHAT_NAME}
 
 Shared communication channel. Keep messages short (<10 lines). For longer content, write to \`/tmp/chat-attachment-<timestamp>.md\` and reference it here.
 
 ---
-EOF
+CHAT_FILE_TEMPLATE
   fi
 }
 
@@ -163,12 +163,12 @@ chat_append() {
   local ts
   ts=$(chat_timestamp)
 
-  cat >> "$CHAT_FILE" <<EOF
+  cat >> "$CHAT_FILE" <<CHAT_MESSAGE
 
 ### ${from} — ${ts}
 
 ${message}
-EOF
+CHAT_MESSAGE
 }
 
 # Get new messages since cursor for an agent

--- a/lib/tui/common.sh
+++ b/lib/tui/common.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+chat_tui_root() {
+  if [ -n "${CHAT_TUI_ROOT:-}" ]; then
+    printf '%s\n' "$CHAT_TUI_ROOT"
+    return 0
+  fi
+  cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
+}
+
+# shellcheck source=../chat.sh
+source "$(chat_tui_root)/lib/chat.sh"
+
+chat_tui_state_dir() {
+  if [ -n "${CHAT_TUI_STATE_DIR:-}" ]; then
+    printf '%s\n' "$CHAT_TUI_STATE_DIR"
+  else
+    printf '%s/.tui/default\n' "$CHAT_DATA_DIR"
+  fi
+}
+
+chat_tui_ensure_state() {
+  mkdir -p "$(chat_tui_state_dir)"
+}
+
+chat_tui_state_path() {
+  local key="$1"
+  printf '%s/%s\n' "$(chat_tui_state_dir)" "$key"
+}
+
+chat_tui_read_state() {
+  local key="$1"
+  local default="$2"
+  local path
+  path="$(chat_tui_state_path "$key")"
+  if [ -s "$path" ]; then
+    cat "$path"
+  else
+    printf '%s\n' "$default"
+  fi
+}
+
+chat_tui_write_state() {
+  local key="$1"
+  local value="$2"
+  chat_tui_ensure_state
+  printf '%s\n' "$value" > "$(chat_tui_state_path "$key")"
+}
+
+chat_tui_current_channel() {
+  chat_tui_read_state channel "${CHAT_CHANNEL:-default}"
+}
+
+chat_tui_current_identity() {
+  chat_tui_read_state identity "${CHAT_IDENTITY:-}"
+}
+
+chat_tui_clean() {
+  local unset_args=()
+  local name
+  while IFS='=' read -r name _; do
+    case "$name" in
+      usage_*) unset_args+=("-u" "$name") ;;
+    esac
+  done < <(env)
+
+  env ${unset_args[@]+"${unset_args[@]}"} mise run -C "$(chat_tui_root)" -q "$@"
+}
+
+chat_tui_gum() {
+  "${GUM:-gum}" "$@"
+}

--- a/lib/tui/layout.kdl
+++ b/lib/tui/layout.kdl
@@ -1,0 +1,18 @@
+layout {
+    pane split_direction="horizontal" {
+        pane split_direction="vertical" size="70%" {
+            pane name="rooms" size="25%" command="bash" {
+                args "-c" "exec mise run -C \"$CHAT_TUI_ROOT\" -q tui:rooms"
+            }
+            pane name="view" command="bash" {
+                args "-c" "exec mise run -C \"$CHAT_TUI_ROOT\" -q tui:view"
+            }
+        }
+        pane name="compose" size="30%" focus=true command="bash" {
+            args "-c" "exec mise run -C \"$CHAT_TUI_ROOT\" -q tui:compose"
+        }
+    }
+    pane size=1 borderless=true {
+        plugin location="zellij:compact-bar"
+    }
+}

--- a/lib/tui/render-messages
+++ b/lib/tui/render-messages
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+jq -r '
+  .[]
+  | (.id // "") as $id
+  | "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+    + ((.timestamp // "") + "  " + (.sender // "?") + (if $id == "" then "" else "  " + $id end) + "\n")
+    + ((.body // "") + "\n")
+'

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,8 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 [tools]
 jq = "latest"
 gum = "latest"
+zellij = "0.44.3"
+fzf = "0.73.1"
 uv = "latest"
 bats = "1.13.0"
 "shiv:blobs" = "0.1"

--- a/readme/mise.ts
+++ b/readme/mise.ts
@@ -38,8 +38,16 @@ function stringAttr(attrs: UsageAttrs, key: string): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-function parseMiseTask(taskDir: string, filename: string, name = filename): MiseCommand {
-  const src = readFileSync(join(taskDir, filename), "utf-8");
+function taskNameFromPath(relativePath: string): string {
+  const parts = relativePath.split("/");
+  if (parts[parts.length - 1] === "_default") {
+    parts.pop();
+  }
+  return parts.join(":");
+}
+
+function parseMiseTask(taskDir: string, relativePath: string, name = taskNameFromPath(relativePath)): MiseCommand {
+  const src = readFileSync(join(taskDir, relativePath), "utf-8");
   const lines = src.split("\n");
 
   const desc = lines.find(l => l.startsWith("#MISE description="))
@@ -86,22 +94,31 @@ function parseMiseTask(taskDir: string, filename: string, name = filename): Mise
 }
 
 export function parseMiseTasks(taskDir: string): MiseCommand[] {
-  return readdirSync(taskDir, { withFileTypes: true })
-    .filter(entry => !entry.name.startsWith("."))
-    .flatMap(entry => {
+  function collect(relativeDir = ""): MiseCommand[] {
+    const dir = join(taskDir, relativeDir);
+    const commands: MiseCommand[] = [];
+
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
+
+      const relativePath = relativeDir ? join(relativeDir, entry.name) : entry.name;
       if (entry.isFile() && !entry.name.startsWith("_")) {
-        return [parseMiseTask(taskDir, entry.name)];
+        commands.push(parseMiseTask(taskDir, relativePath));
       }
 
       if (entry.isDirectory() && !entry.name.startsWith("_")) {
-        const defaultTask = join(entry.name, "_default");
+        const defaultTask = join(relativePath, "_default");
         if (existsSync(join(taskDir, defaultTask))) {
-          return [parseMiseTask(taskDir, defaultTask, entry.name)];
+          commands.push(parseMiseTask(taskDir, defaultTask));
         }
+        commands.push(...collect(relativePath));
       }
+    }
 
-      return [];
-    })
+    return commands;
+  }
+
+  return collect()
     .filter(command => !command.hidden)
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/readme/mise.ts
+++ b/readme/mise.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from "fs";
+import { existsSync, readFileSync, readdirSync } from "fs";
 import { join } from "path";
 
 export interface MiseCommand {
@@ -38,7 +38,7 @@ function stringAttr(attrs: UsageAttrs, key: string): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-function parseMiseTask(taskDir: string, filename: string): MiseCommand {
+function parseMiseTask(taskDir: string, filename: string, name = filename): MiseCommand {
   const src = readFileSync(join(taskDir, filename), "utf-8");
   const lines = src.split("\n");
 
@@ -82,13 +82,26 @@ function parseMiseTask(taskDir: string, filename: string): MiseCommand {
     }
   }
 
-  return { name: filename, description: desc, flags, args, hidden };
+  return { name, description: desc, flags, args, hidden };
 }
 
 export function parseMiseTasks(taskDir: string): MiseCommand[] {
   return readdirSync(taskDir, { withFileTypes: true })
-    .filter(entry => entry.isFile() && !entry.name.startsWith(".") && !entry.name.startsWith("_"))
-    .map(entry => parseMiseTask(taskDir, entry.name))
+    .filter(entry => !entry.name.startsWith("."))
+    .flatMap(entry => {
+      if (entry.isFile() && !entry.name.startsWith("_")) {
+        return [parseMiseTask(taskDir, entry.name)];
+      }
+
+      if (entry.isDirectory() && !entry.name.startsWith("_")) {
+        const defaultTask = join(entry.name, "_default");
+        if (existsSync(join(taskDir, defaultTask))) {
+          return [parseMiseTask(taskDir, defaultTask, entry.name)];
+        }
+      }
+
+      return [];
+    })
     .filter(command => !command.hidden)
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -608,7 +608,7 @@ for c in channels:
   local newer_file="$CHAT_DATA_DIR/newer-chat.md"
   mkdir -p "$CHAT_DATA_DIR/.cursors/older-chat" "$CHAT_DATA_DIR/.cursors/newer-chat"
 
-  cat > "$older_file" <<'EOF'
+  cat > "$older_file" <<'OLDER_CHAT'
 # older-chat
 
 ---
@@ -616,9 +616,9 @@ for c in channels:
 ### alice — 2025-01-01 10:00
 
 old message
-EOF
+OLDER_CHAT
 
-  cat > "$newer_file" <<'EOF'
+  cat > "$newer_file" <<'NEWER_CHAT'
 # newer-chat
 
 ---
@@ -626,7 +626,7 @@ EOF
 ### bob — 2026-03-25 10:00
 
 new message
-EOF
+NEWER_CHAT
 
   run chat list
   [ "$status" -eq 0 ]

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -1159,6 +1159,35 @@ assert 'unread' not in data, f'unread should not be present without --as, got: {
   [[ "$output" == *"test-chat"* ]]
 }
 
+@test "task tui: pane tasks do not leak clear errors without TERM" {
+  send_message "bob" "pane render"
+  run chat tui test-chat --as alice --session test-ui --dry-run
+  [ "$status" -eq 0 ]
+
+  export CHAT_TUI_ROOT="$CHAT_REPO_ROOT"
+  export CHAT_TUI_STATE_DIR="$CHAT_DATA_DIR/.tui/test-ui"
+  export CHAT_TUI_LAST=5
+  export CHAT_TUI_POLL=1
+
+  TERM= run chat tui:view --once
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pane render"* ]]
+  [[ "$output" != *"unknown terminal type"* ]]
+  [[ "$output" != *"TERM environment variable not set"* ]]
+
+  TERM= run chat tui:compose --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"compose"* ]]
+  [[ "$output" != *"unknown terminal type"* ]]
+  [[ "$output" != *"TERM environment variable not set"* ]]
+}
+
+@test "task tui: README documents independently runnable pane tasks" {
+  grep -q '^### chat tui:rooms$' "$CHAT_REPO_ROOT/README.md"
+  grep -q '^### chat tui:view$' "$CHAT_REPO_ROOT/README.md"
+  grep -q '^### chat tui:compose$' "$CHAT_REPO_ROOT/README.md"
+}
+
 # ============================================================================
 # non-existent channel — read-only commands should fail, send should create
 # ============================================================================

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -1107,6 +1107,24 @@ assert 'unread' not in data, f'unread should not be present without --as, got: {
   [[ "$output" == *"hello @carol"* ]]
 }
 
+@test "task wait: --mentioned does not prefix-match longer identities" {
+  mark_read "ann"
+  send_message "bob" "hello @anna"
+
+  run chat wait test-chat --as ann --mentioned --timeout 1 --poll 1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Timed out"* ]]
+}
+
+@test "task wait: --mentioned accepts punctuation-delimited mention" {
+  mark_read "ann"
+  send_message "bob" "hello @ann, please look"
+
+  run chat wait test-chat --as ann --mentioned --timeout 1 --poll 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello @ann, please look"* ]]
+}
+
 # ============================================================================
 # tui task
 # ============================================================================

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -1047,6 +1047,119 @@ assert 'unread' not in data, f'unread should not be present without --as, got: {
 }
 
 # ============================================================================
+# wait task
+# ============================================================================
+
+@test "task wait: --by gates on sender and prints unseen context" {
+  mark_read "alice"
+  send_message "bob" "context before gate"
+  send_message "or" "gate from or"
+
+  run chat wait test-chat --as alice --by or --timeout 1 --poll 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"context before gate"* ]]
+  [[ "$output" == *"gate from or"* ]]
+}
+
+@test "task wait: --from is an alias for --by" {
+  mark_read "alice"
+  send_message "or" "from alias gate"
+
+  run chat wait test-chat --as alice --from or --timeout 1 --poll 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"from alias gate"* ]]
+}
+
+@test "task wait: --by times out when sender does not match" {
+  mark_read "alice"
+  send_message "bob" "not from or"
+
+  run chat wait test-chat --as alice --by or --timeout 1 --poll 1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Timed out"* ]]
+  [[ "$output" == *"no matching messages"* ]]
+}
+
+@test "task wait: --mentioned gates on waiting identity mention" {
+  mark_read "alice"
+  send_message "bob" "context before mention"
+  send_message "or" "hey @alice"
+
+  run chat wait test-chat --as alice --mentioned --timeout 1 --poll 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"context before mention"* ]]
+  [[ "$output" == *"hey @alice"* ]]
+}
+
+@test "task wait: --mentioned requires identity" {
+  unset CHAT_IDENTITY
+  run chat wait test-chat --mentioned --timeout 1 --poll 1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--mentioned requires an identity"* ]]
+}
+
+@test "task wait: --mention gates on explicit mention" {
+  mark_read "alice"
+  send_message "bob" "hello @carol"
+
+  run chat wait test-chat --as alice --mention carol --timeout 1 --poll 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello @carol"* ]]
+}
+
+# ============================================================================
+# tui task
+# ============================================================================
+
+@test "task tui: --dry-run prepares state without attaching" {
+  run chat tui test-chat --as alice --session test-ui --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"prepared chat tui session test-ui"* ]]
+  [[ "$output" == *"pane_tasks=tui:rooms,tui:view,tui:compose"* ]]
+  [[ "$output" == *"command=zellij attach"* ]]
+  [ "$(cat "$CHAT_DATA_DIR/.tui/test-ui/channel")" = "test-chat" ]
+  [ "$(cat "$CHAT_DATA_DIR/.tui/test-ui/identity")" = "alice" ]
+}
+
+@test "task tui: requires identity" {
+  unset CHAT_IDENTITY
+  run chat tui test-chat --dry-run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"identity required"* ]]
+}
+
+@test "task tui: fails on non-existent channel" {
+  run chat tui no-such-channel --as alice --dry-run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "task tui: pane tasks can be evaluated independently" {
+  send_message "bob" "pane render"
+  run chat tui test-chat --as alice --session test-ui --dry-run
+  [ "$status" -eq 0 ]
+
+  export CHAT_TUI_ROOT="$CHAT_REPO_ROOT"
+  export CHAT_TUI_STATE_DIR="$CHAT_DATA_DIR/.tui/test-ui"
+  export CHAT_TUI_LAST=5
+  export CHAT_TUI_POLL=1
+
+  run chat tui:rooms --print
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"▶ test-chat"* ]]
+
+  run chat tui:view --once
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"chat:test-chat as:alice"* ]]
+  [[ "$output" == *"pane render"* ]]
+
+  run chat tui:compose --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"compose"* ]]
+  [[ "$output" == *"test-chat"* ]]
+}
+
+# ============================================================================
 # non-existent channel — read-only commands should fail, send should create
 # ============================================================================
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -62,7 +62,7 @@ _setup_mock_blobs() {
   export BLOBS_LOG="$BATS_TEST_TMPDIR/blobs.log"
   export BLOBS_STDIN="$BATS_TEST_TMPDIR/blobs.stdin"
   export BLOBS="$BATS_TEST_TMPDIR/blobs"
-  cat > "$BLOBS" <<'EOF'
+  cat > "$BLOBS" <<'BLOBS_MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$BLOBS_LOG"
@@ -72,7 +72,7 @@ if [ "$1" = "put" ]; then
 fi
 echo "unexpected blobs invocation: $*" >&2
 exit 1
-EOF
+BLOBS_MOCK
   chmod +x "$BLOBS"
 }
 


### PR DESCRIPTION
## Summary

- add `chat wait` sender/mention predicates plus polling/loop controls
- add `chat tui` as a zellij/gum/fzf cockpit
- implement TUI panes as addressable mise subtasks: `tui:rooms`, `tui:view`, `tui:compose`
- update README generation and BATS coverage

## Validation

- `mise run test`
- `mise run readme --check`
- `git diff --check`
- `zellij setup --dump-layout lib/tui/layout.kdl >/dev/null`
- `codebase lint "$PWD"`
- targeted `bats test/tasks.bats --filter 'task (wait|tui)'`
