### PR TITLE
fix: avoid prefix matches in wait mentions

### DIFF
--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -116,11 +116,23 @@ _count_matching_messages() {
     -v self="$self" \
     -v sender_filter="$sender_filter" \
     -v mention_filter="$mention_filter" '
+      function has_mention(text, identity,    needle, start, pos, after) {
+        if (identity == "") return 1
+        needle = "@" identity
+        start = 1
+        while ((pos = index(substr(text, start), needle)) > 0) {
+          pos = start + pos - 1
+          after = substr(text, pos + length(needle), 1)
+          if (after == "" || after !~ /[[:alnum:]_.-]/) return 1
+          start = pos + length(needle)
+        }
+        return 0
+      }
       function finish_message() {
         if (!in_message) return
         if (self != "" && sender == self) return
         if (sender_filter != "" && sender != sender_filter) return
-        if (mention_filter != "" && index(body, "@" mention_filter) == 0) return
+        if (mention_filter != "" && !has_mention(body, mention_filter)) return
         count++
       }
       /^### / {

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -1107,6 +1107,24 @@ assert 'unread' not in data, f'unread should not be present without --as, got: {
   [[ "$output" == *"hello @carol"* ]]
 }
 
+@test "task wait: --mentioned does not prefix-match longer identities" {
+  mark_read "ann"
+  send_message "bob" "hello @anna"
+
+  run chat wait test-chat --as ann --mentioned --timeout 1 --poll 1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Timed out"* ]]
+}
+
+@test "task wait: --mentioned accepts punctuation-delimited mention" {
+  mark_read "ann"
+  send_message "bob" "hello @ann, please look"
+
+  run chat wait test-chat --as ann --mentioned --timeout 1 --poll 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello @ann, please look"* ]]
+}
+
 # ============================================================================
 # tui task
 # ============================================================================


### PR DESCRIPTION
## Summary

- require mention waits to match a whole @identity token instead of any prefix
- add regressions for @ann vs @anna and punctuation-delimited @ann

## Validation

- `bats test/tasks.bats --filter 'task wait'`\n- `mise run test`\n- `codebase lint "$PWD"`\n- `git diff --check`\n