### PR TITLE
Document nested TUI tasks

### DIFF
--- a/.mise/tasks/tui/compose
+++ b/.mise/tasks/tui/compose
@@ -12,7 +12,7 @@ height="${CHAT_TUI_COMPOSE_HEIGHT:-6}"
 chat_tui_ensure_state
 
 try_clear() {
-  if ! clear; then
+  if ! clear 2>/dev/null; then
     : # clear can fail when TERM is missing or unsupported
   fi
 }

--- a/.mise/tasks/tui/rooms
+++ b/.mise/tasks/tui/rooms
@@ -11,7 +11,7 @@ print_once="${usage_print:-false}"
 chat_tui_ensure_state
 
 try_clear() {
-  if ! clear; then
+  if ! clear 2>/dev/null; then
     : # clear can fail when TERM is missing or unsupported
   fi
 }

--- a/.mise/tasks/tui/view
+++ b/.mise/tasks/tui/view
@@ -23,7 +23,7 @@ try_tput() {
 }
 
 try_clear() {
-  if ! clear; then
+  if ! clear 2>/dev/null; then
     : # clear can fail when TERM is missing or unsupported
   fi
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agents on the same machine exchange short messages through a shared channel.
 No server. No daemon. Just files, cursors, and bash.
 
 ![lang: bash](https://img.shields.io/badge/lang-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 199 passing](https://img.shields.io/badge/tests-199%20passing-brightgreen?style=flat)](test/)
+[![tests: 201 passing](https://img.shields.io/badge/tests-201%20passing-brightgreen?style=flat)](test/)
 ![deps: jq + gum + fzf + zellij + blobs](https://img.shields.io/badge/deps-jq%20%2B%20gum%20%2B%20fzf%20%2B%20zellij%20%2B%20blobs-blue?style=flat)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)
 
@@ -93,7 +93,7 @@ FYI — just pushed the load testing scenarios to the note.
 
 ## Commands
 
-**13 commands**, each a standalone bash script in `.mise/tasks/`:
+**18 commands**, each a standalone bash script in `.mise/tasks/`:
 
 
 ### chat clear
@@ -107,6 +107,32 @@ chat clear [--yes] [chat]
 | Flag    | Description       | Default |
 | ------- | ----------------- | ------- |
 | `--yes` | Skip confirmation | —       |
+
+
+### chat cursor:clear
+
+Clear your cursor (mark everything as unread)
+
+```
+chat cursor:clear [--as <as>] [chat]
+```
+
+| Flag   | Description                             | Default |
+| ------ | --------------------------------------- | ------- |
+| `--as` | Your identity (default: $CHAT_IDENTITY) | —       |
+
+
+### chat cursor:undo
+
+Undo the last cursor advance (restore previous read position)
+
+```
+chat cursor:undo [--as <as>] [chat]
+```
+
+| Flag   | Description                             | Default |
+| ------ | --------------------------------------- | ------- |
+| `--as` | Your identity (default: $CHAT_IDENTITY) | —       |
 
 
 ### chat export
@@ -261,6 +287,45 @@ chat tui [--as <as>] [--session <session>] [--fresh] [--last <last>] [--poll <se
 | `--dry-run` | Prepare state and print the launch command without attaching | —          |
 
 
+### chat tui:compose
+
+Open the compose pane for chat tui
+
+```
+chat tui:compose [--dry-run]
+```
+
+| Flag        | Description                                                | Default |
+| ----------- | ---------------------------------------------------------- | ------- |
+| `--dry-run` | Print the compose target and exit before opening gum write | —       |
+
+
+### chat tui:rooms
+
+Select the active room for chat tui
+
+```
+chat tui:rooms [--print]
+```
+
+| Flag      | Description                                        | Default |
+| --------- | -------------------------------------------------- | ------- |
+| `--print` | Print selectable rooms once instead of opening fzf | —       |
+
+
+### chat tui:view
+
+Render the live message pane for chat tui
+
+```
+chat tui:view [--once]
+```
+
+| Flag     | Description                             | Default |
+| -------- | --------------------------------------- | ------- |
+| `--once` | Render once and exit instead of polling | —       |
+
+
 ### chat unread
 
 Count total unread messages across all channels
@@ -384,7 +449,7 @@ cd chat && mise trust && mise install
 mise run test
 ```
 
-199 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
+201 tests across 3 suites, using [BATS](https://github.com/bats-core/bats-core).
 
 <br />
 

--- a/readme/mise.ts
+++ b/readme/mise.ts
@@ -38,8 +38,16 @@ function stringAttr(attrs: UsageAttrs, key: string): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-function parseMiseTask(taskDir: string, filename: string, name = filename): MiseCommand {
-  const src = readFileSync(join(taskDir, filename), "utf-8");
+function taskNameFromPath(relativePath: string): string {
+  const parts = relativePath.split("/");
+  if (parts[parts.length - 1] === "_default") {
+    parts.pop();
+  }
+  return parts.join(":");
+}
+
+function parseMiseTask(taskDir: string, relativePath: string, name = taskNameFromPath(relativePath)): MiseCommand {
+  const src = readFileSync(join(taskDir, relativePath), "utf-8");
   const lines = src.split("\n");
 
   const desc = lines.find(l => l.startsWith("#MISE description="))
@@ -86,22 +94,31 @@ function parseMiseTask(taskDir: string, filename: string, name = filename): Mise
 }
 
 export function parseMiseTasks(taskDir: string): MiseCommand[] {
-  return readdirSync(taskDir, { withFileTypes: true })
-    .filter(entry => !entry.name.startsWith("."))
-    .flatMap(entry => {
+  function collect(relativeDir = ""): MiseCommand[] {
+    const dir = join(taskDir, relativeDir);
+    const commands: MiseCommand[] = [];
+
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
+
+      const relativePath = relativeDir ? join(relativeDir, entry.name) : entry.name;
       if (entry.isFile() && !entry.name.startsWith("_")) {
-        return [parseMiseTask(taskDir, entry.name)];
+        commands.push(parseMiseTask(taskDir, relativePath));
       }
 
       if (entry.isDirectory() && !entry.name.startsWith("_")) {
-        const defaultTask = join(entry.name, "_default");
+        const defaultTask = join(relativePath, "_default");
         if (existsSync(join(taskDir, defaultTask))) {
-          return [parseMiseTask(taskDir, defaultTask, entry.name)];
+          commands.push(parseMiseTask(taskDir, defaultTask));
         }
+        commands.push(...collect(relativePath));
       }
+    }
 
-      return [];
-    })
+    return commands;
+  }
+
+  return collect()
     .filter(command => !command.hidden)
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/test/tasks.bats
+++ b/test/tasks.bats
@@ -1159,6 +1159,35 @@ assert 'unread' not in data, f'unread should not be present without --as, got: {
   [[ "$output" == *"test-chat"* ]]
 }
 
+@test "task tui: pane tasks do not leak clear errors without TERM" {
+  send_message "bob" "pane render"
+  run chat tui test-chat --as alice --session test-ui --dry-run
+  [ "$status" -eq 0 ]
+
+  export CHAT_TUI_ROOT="$CHAT_REPO_ROOT"
+  export CHAT_TUI_STATE_DIR="$CHAT_DATA_DIR/.tui/test-ui"
+  export CHAT_TUI_LAST=5
+  export CHAT_TUI_POLL=1
+
+  TERM= run chat tui:view --once
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pane render"* ]]
+  [[ "$output" != *"unknown terminal type"* ]]
+  [[ "$output" != *"TERM environment variable not set"* ]]
+
+  TERM= run chat tui:compose --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"compose"* ]]
+  [[ "$output" != *"unknown terminal type"* ]]
+  [[ "$output" != *"TERM environment variable not set"* ]]
+}
+
+@test "task tui: README documents independently runnable pane tasks" {
+  grep -q '^### chat tui:rooms$' "$CHAT_REPO_ROOT/README.md"
+  grep -q '^### chat tui:view$' "$CHAT_REPO_ROOT/README.md"
+  grep -q '^### chat tui:compose$' "$CHAT_REPO_ROOT/README.md"
+}
+
 # ============================================================================
 # non-existent channel — read-only commands should fail, send should create
 # ============================================================================


### PR DESCRIPTION
## Summary
- include nested mise tasks (for example `tui:rooms`, `tui:view`, `tui:compose`) in generated README command discovery
- add README coverage for the independently runnable TUI pane tasks
- silence `clear` diagnostics when pane tasks run without a usable `TERM`

## Tests
- `mise run test`
